### PR TITLE
[mlir][flang] WIP patch for CSE AA callback

### DIFF
--- a/flang/test/Lower/array-constructor-2.f90
+++ b/flang/test/Lower/array-constructor-2.f90
@@ -90,8 +90,7 @@ subroutine test3(a)
   ! CHECK-NEXT: fir.store
   ! CHECK: fir.freemem %[[tmp]]
   ! CHECK: fir.freemem %[[tmp2]]
-  ! CHECK: %[[alli:.*]] = fir.box_addr %{{.*}} : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
-  ! CHECK: fir.freemem %[[alli]]
+  ! CHECK: fir.freemem %{{.+}}
   ! CHECK: fir.freemem %[[hp1]]
   a = (/ b, test3c() /)
 end subroutine test3

--- a/flang/test/Lower/array-expression-slice-1.f90
+++ b/flang/test/Lower/array-expression-slice-1.f90
@@ -1,345 +1,328 @@
 ! RUN: bbc -hlfir=false -fwrapv -o - --outline-intrinsics %s | FileCheck %s
 
-! CHECK-LABEL: func @_QQmain() attributes {fir.bindc_name = "p"} {
-! CHECK-DAG:         %[[VAL_0:.*]] = arith.constant 10 : index
-! CHECK-DAG:         %[[VAL_4:.*]] = arith.constant 2 : index
-! CHECK-DAG:         %[[VAL_5:.*]] = arith.constant 1 : index
-! CHECK-DAG:         %[[VAL_6:.*]] = arith.constant 0 : index
-! CHECK-DAG:         %[[VAL_8:.*]] = arith.constant 8 : i64
-! CHECK-DAG:         %[[VAL_11:.*]] = arith.constant 3 : index
-! CHECK-DAG:         %[[VAL_13:.*]] = arith.constant 2 : i64
-! CHECK-DAG:         %[[VAL_14:.*]] = arith.constant 7 : i64
-! CHECK-DAG:         %[[VAL_16:.*]] = arith.constant 4 : i64
-! CHECK-DAG:         %[[VAL_18:.*]] = arith.constant 6 : i32
-! CHECK-DAG:         %[[VAL_19:.*]] = arith.constant 0 : i64
-! CHECK-DAG:         %[[VAL_20:.*]] = arith.constant 1 : i64
-! CHECK-DAG:         %[[VAL_21:.*]] = arith.constant 3 : i64
-! CHECK-DAG:         %[[VAL_22:.*]] = arith.constant 4 : index
-! CHECK-DAG:         %[[VAL_23:.*]] = arith.constant 1 : i32
-! CHECK-DAG:         %[[VAL_24:.*]] = arith.constant 0 : i32
-! CHECK-DAG:         %[[VAL_25:.*]] = fir.address_of(@_QFEa1) : !fir.ref<!fir.array<10x10xf32>>
-! CHECK-DAG:         %[[VAL_26:.*]] = fir.alloca !fir.array<3xf32> {bindc_name = "a2", uniq_name = "_QFEa2"}
-! CHECK-DAG:         %[[VAL_27:.*]] = fir.address_of(@_QFEa3) : !fir.ref<!fir.array<10xf32>>
-! CHECK-DAG:         %[[VAL_28:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFEi"}
-! CHECK-DAG:         %[[VAL_29:.*]] = fir.alloca !fir.array<3xi32> {bindc_name = "iv", uniq_name = "_QFEiv"}
-! CHECK-DAG:         %[[VAL_30:.*]] = fir.alloca i32 {bindc_name = "j", uniq_name = "_QFEj"}
-! CHECK-DAG:         %[[VAL_31:.*]] = fir.alloca i32 {bindc_name = "k", uniq_name = "_QFEk"}
-! CHECK:         fir.store %[[VAL_24]] to %[[VAL_31]] : !fir.ref<i32>
-! CHECK:         %[[STEP:.*]] = fir.convert %[[VAL_5]] : (index) -> i32
-! CHECK:         br ^bb1(%[[STEP]], %[[VAL_0]] : i32, index)
-! CHECK:       ^bb1(%[[VAL_32:.*]]: i32, %[[VAL_33:.*]]: index):
-! CHECK:         %[[VAL_34:.*]] = arith.cmpi sgt, %[[VAL_33]], %[[VAL_6]] : index
-! CHECK:         cond_br %[[VAL_34]], ^bb2, ^bb6
-! CHECK:       ^bb2:
-! CHECK:         fir.store %[[VAL_32]] to %[[VAL_30]] : !fir.ref<i32>
-! CHECK:         br ^bb3(%[[STEP]], %[[VAL_0]] : i32, index)
-! CHECK:       ^bb3(%[[VAL_36:.*]]: i32, %[[VAL_37:.*]]: index):
-! CHECK:         %[[VAL_38:.*]] = arith.cmpi sgt, %[[VAL_37]], %[[VAL_6]] : index
-! CHECK:         cond_br %[[VAL_38]], ^bb4, ^bb5
-! CHECK:       ^bb4:
-! CHECK:         fir.store %[[VAL_36]] to %[[VAL_28]] : !fir.ref<i32>
-! CHECK:         %[[VAL_40:.*]] = fir.load %[[VAL_31]] : !fir.ref<i32>
-! CHECK:         %[[VAL_41:.*]] = arith.addi %[[VAL_40]], %[[VAL_23]] : i32
-! CHECK:         fir.store %[[VAL_41]] to %[[VAL_31]] : !fir.ref<i32>
-! CHECK:         %[[VAL_42:.*]] = fir.load %[[VAL_31]] : !fir.ref<i32>
-! CHECK:         %[[VAL_43:.*]] = fir.convert %[[VAL_42]] : (i32) -> f32
-! CHECK:         %[[VAL_44:.*]] = fir.call @fir.cos.contract.f32.f32(%[[VAL_43]]) {{.*}}: (f32) -> f32
-! CHECK:         %[[VAL_45:.*]] = fir.load %[[VAL_28]] : !fir.ref<i32>
-! CHECK:         %[[VAL_46:.*]] = fir.convert %[[VAL_45]] : (i32) -> i64
-! CHECK:         %[[VAL_47:.*]] = arith.subi %[[VAL_46]], %[[VAL_20]] : i64
-! CHECK:         %[[VAL_48:.*]] = fir.load %[[VAL_30]] : !fir.ref<i32>
-! CHECK:         %[[VAL_49:.*]] = fir.convert %[[VAL_48]] : (i32) -> i64
-! CHECK:         %[[VAL_50:.*]] = arith.subi %[[VAL_49]], %[[VAL_20]] : i64
-! CHECK:         %[[VAL_51:.*]] = fir.coordinate_of %[[VAL_25]], %[[VAL_47]], %[[VAL_50]] : (!fir.ref<!fir.array<10x10xf32>>, i64, i64) -> !fir.ref<f32>
-! CHECK:         fir.store %[[VAL_44]] to %[[VAL_51]] : !fir.ref<f32>
-! CHECK:         %[[LOADI:.*]] = fir.load %[[VAL_28]] : !fir.ref<i32>
-! CHECK:         %[[VAL_52:.*]] = arith.addi %[[LOADI]], %[[STEP]] : i32
-! CHECK:         %[[VAL_53:.*]] = arith.subi %[[VAL_37]], %[[VAL_5]] : index
-! CHECK:         br ^bb3(%[[VAL_52]], %[[VAL_53]] : i32, index)
-! CHECK:       ^bb5:
-! CHECK:         fir.store %[[VAL_36]] to %[[VAL_28]] : !fir.ref<i32>
-! CHECK:         %[[VAL_55:.*]] = fir.load %[[VAL_31]] : !fir.ref<i32>
-! CHECK:         %[[VAL_56:.*]] = fir.convert %[[VAL_55]] : (i32) -> f32
-! CHECK:         %[[VAL_57:.*]] = fir.call @fir.sin.contract.f32.f32(%[[VAL_56]]) {{.*}}: (f32) -> f32
-! CHECK:         %[[VAL_58:.*]] = fir.load %[[VAL_30]] : !fir.ref<i32>
-! CHECK:         %[[VAL_59:.*]] = fir.convert %[[VAL_58]] : (i32) -> i64
-! CHECK:         %[[VAL_60:.*]] = arith.subi %[[VAL_59]], %[[VAL_20]] : i64
-! CHECK:         %[[VAL_61:.*]] = fir.coordinate_of %[[VAL_27]], %[[VAL_60]] : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
-! CHECK:         fir.store %[[VAL_57]] to %[[VAL_61]] : !fir.ref<f32>
-! CHECK:         %[[LOADJ:.*]] = fir.load %[[VAL_30]] : !fir.ref<i32>
-! CHECK:         %[[VAL_62:.*]] = arith.addi %[[LOADJ]], %[[STEP]] : i32
-! CHECK:         %[[VAL_63:.*]] = arith.subi %[[VAL_33]], %[[VAL_5]] : index
-! CHECK:         br ^bb1(%[[VAL_62]], %[[VAL_63]] : i32, index)
-! CHECK:       ^bb6:
-! CHECK:         fir.store %[[VAL_32]] to %[[VAL_30]] : !fir.ref<i32>
-! CHECK:         %[[VAL_65:.*]] = fir.shape %[[VAL_11]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_66:.*]] = fir.undefined index
-! CHECK:         %[[VAL_67:.*]] = fir.shape %[[VAL_0]], %[[VAL_0]] : (index, index) -> !fir.shape<2>
-! CHECK:         %[[VAL_68:.*]] = fir.slice %[[VAL_16]], %[[VAL_66]], %[[VAL_66]], %[[VAL_4]], %[[VAL_0]], %[[VAL_11]] : (i64, index, index, index, index, index) -> !fir.slice<2>
-! CHECK:         br ^bb7(%[[VAL_6]], %[[VAL_11]] : index, index)
-! CHECK:       ^bb7(%[[VAL_69:.*]]: index, %[[VAL_70:.*]]: index):
-! CHECK:         %[[VAL_71:.*]] = arith.cmpi sgt, %[[VAL_70]], %[[VAL_6]] : index
-! CHECK:         cond_br %[[VAL_71]], ^bb8, ^bb9
-! CHECK:       ^bb8:
-! CHECK:         %[[VAL_72:.*]] = arith.addi %[[VAL_69]], %[[VAL_5]] : index
-! CHECK:         %[[VAL_73:.*]] = fir.array_coor %[[VAL_25]](%[[VAL_67]]) {{\[}}%[[VAL_68]]] %[[VAL_22]], %[[VAL_72]] : (!fir.ref<!fir.array<10x10xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
-! CHECK:         %[[VAL_74:.*]] = fir.load %[[VAL_73]] : !fir.ref<f32>
-! CHECK:         %[[VAL_75:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_65]]) %[[VAL_72]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:         fir.store %[[VAL_74]] to %[[VAL_75]] : !fir.ref<f32>
-! CHECK:         %[[VAL_76:.*]] = arith.subi %[[VAL_70]], %[[VAL_5]] : index
-! CHECK:         br ^bb7(%[[VAL_72]], %[[VAL_76]] : index, index)
-! CHECK:       ^bb9:
-! CHECK:         %[[VAL_77:.*]] = fir.coordinate_of %[[VAL_25]], %[[VAL_21]], %[[VAL_20]] : (!fir.ref<!fir.array<10x10xf32>>, i64, i64) -> !fir.ref<f32>
-! CHECK:         %[[VAL_78:.*]] = fir.load %[[VAL_77]] : !fir.ref<f32>
-! CHECK:         %[[VAL_79:.*]] = fir.coordinate_of %[[VAL_26]], %[[VAL_19]] : (!fir.ref<!fir.array<3xf32>>, i64) -> !fir.ref<f32>
-! CHECK:         %[[VAL_80:.*]] = fir.load %[[VAL_79]] : !fir.ref<f32>
-! CHECK:         %[[VAL_81:.*]] = arith.cmpf une, %[[VAL_78]], %[[VAL_80]] {{.*}} : f32
-! CHECK:         cond_br %[[VAL_81]], ^bb10, ^bb11
-! CHECK:       ^bb10:
-! CHECK:         %[[VAL_82:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
-! CHECK:         %[[VAL_83:.*]] = fir.convert %[[VAL_82]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_84:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_83]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_85:.*]] = fir.address_of(@_QQclX6D69736D617463682031) : !fir.ref<!fir.char<1,10>>
-! CHECK:         %[[VAL_86:.*]] = fir.convert %[[VAL_85]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_87:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
-! CHECK:         %[[VAL_88:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_84]], %[[VAL_86]], %[[VAL_87]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
-! CHECK:         %[[VAL_89:.*]] = fir.load %[[VAL_79]] : !fir.ref<f32>
-! CHECK:         %[[VAL_90:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_84]], %[[VAL_89]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_91:.*]] = fir.load %[[VAL_77]] : !fir.ref<f32>
-! CHECK:         %[[VAL_92:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_84]], %[[VAL_91]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_93:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_84]]) {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb11
-! CHECK:       ^bb11:
-! CHECK:         %[[VAL_94:.*]] = fir.coordinate_of %[[VAL_25]], %[[VAL_21]], %[[VAL_16]] : (!fir.ref<!fir.array<10x10xf32>>, i64, i64) -> !fir.ref<f32>
-! CHECK:         %[[VAL_95:.*]] = fir.load %[[VAL_94]] : !fir.ref<f32>
-! CHECK:         %[[VAL_96:.*]] = fir.coordinate_of %[[VAL_26]], %[[VAL_20]] : (!fir.ref<!fir.array<3xf32>>, i64) -> !fir.ref<f32>
-! CHECK:         %[[VAL_97:.*]] = fir.load %[[VAL_96]] : !fir.ref<f32>
-! CHECK:         %[[VAL_98:.*]] = arith.cmpf une, %[[VAL_95]], %[[VAL_97]] {{.*}} : f32
-! CHECK:         cond_br %[[VAL_98]], ^bb12, ^bb13
-! CHECK:       ^bb12:
-! CHECK:         %[[VAL_99:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
-! CHECK:         %[[VAL_100:.*]] = fir.convert %[[VAL_99]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_101:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_100]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_102:.*]] = fir.address_of(@_QQclX6D69736D617463682032) : !fir.ref<!fir.char<1,10>>
-! CHECK:         %[[VAL_103:.*]] = fir.convert %[[VAL_102]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_104:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
-! CHECK:         %[[VAL_105:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_101]], %[[VAL_103]], %[[VAL_104]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
-! CHECK:         %[[VAL_106:.*]] = fir.load %[[VAL_96]] : !fir.ref<f32>
-! CHECK:         %[[VAL_107:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_101]], %[[VAL_106]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_108:.*]] = fir.load %[[VAL_94]] : !fir.ref<f32>
-! CHECK:         %[[VAL_109:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_101]], %[[VAL_108]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_110:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_101]]) {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb13
-! CHECK:       ^bb13:
-! CHECK:         %[[VAL_111:.*]] = fir.coordinate_of %[[VAL_25]], %[[VAL_21]], %[[VAL_14]] : (!fir.ref<!fir.array<10x10xf32>>, i64, i64) -> !fir.ref<f32>
-! CHECK:         %[[VAL_112:.*]] = fir.load %[[VAL_111]] : !fir.ref<f32>
-! CHECK:         %[[VAL_113:.*]] = fir.coordinate_of %[[VAL_26]], %[[VAL_13]] : (!fir.ref<!fir.array<3xf32>>, i64) -> !fir.ref<f32>
-! CHECK:         %[[VAL_114:.*]] = fir.load %[[VAL_113]] : !fir.ref<f32>
-! CHECK:         %[[VAL_115:.*]] = arith.cmpf une, %[[VAL_112]], %[[VAL_114]] {{.*}} : f32
-! CHECK:         cond_br %[[VAL_115]], ^bb14, ^bb15
-! CHECK:       ^bb14:
-! CHECK:         %[[VAL_116:.*]] = fir.address_of(@_QQclX{{.*}} : !fir.ref<!fir.char<1,
-! CHECK:         %[[VAL_117:.*]] = fir.convert %[[VAL_116]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_118:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_117]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_119:.*]] = fir.address_of(@_QQclX6D69736D617463682033) : !fir.ref<!fir.char<1,10>>
-! CHECK:         %[[VAL_120:.*]] = fir.convert %[[VAL_119]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_121:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
-! CHECK:         %[[VAL_122:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_118]], %[[VAL_120]], %[[VAL_121]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
-! CHECK:         %[[VAL_123:.*]] = fir.load %[[VAL_113]] : !fir.ref<f32>
-! CHECK:         %[[VAL_124:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_118]], %[[VAL_123]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_125:.*]] = fir.load %[[VAL_111]] : !fir.ref<f32>
-! CHECK:         %[[VAL_126:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_118]], %[[VAL_125]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_127:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_118]]) {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb15
-! CHECK:       ^bb15:
-! CHECK:         %[[VAL_128:.*]] = fir.shape %[[VAL_0]] : (index) -> !fir.shape<1>
-! CHECK:         %[[VAL_129:.*]] = fir.slice %[[VAL_5]], %[[VAL_0]], %[[VAL_22]] : (index, index, index) -> !fir.slice<1>
-! CHECK:         br ^bb16(%[[VAL_6]], %[[VAL_11]] : index, index)
-! CHECK:       ^bb16(%[[VAL_130:.*]]: index, %[[VAL_131:.*]]: index):
-! CHECK:         %[[VAL_132:.*]] = arith.cmpi sgt, %[[VAL_131]], %[[VAL_6]] : index
-! CHECK:         cond_br %[[VAL_132]], ^bb17, ^bb18
-! CHECK:       ^bb17:
-! CHECK:         %[[VAL_133:.*]] = arith.addi %[[VAL_130]], %[[VAL_5]] : index
-! CHECK:         %[[VAL_134:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_65]]) %[[VAL_133]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:         %[[VAL_135:.*]] = fir.load %[[VAL_134]] : !fir.ref<f32>
-! CHECK:         %[[VAL_136:.*]] = fir.array_coor %[[VAL_27]](%[[VAL_128]]) {{\[}}%[[VAL_129]]] %[[VAL_133]] : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
-! CHECK:         fir.store %[[VAL_135]] to %[[VAL_136]] : !fir.ref<f32>
-! CHECK:         %[[VAL_137:.*]] = arith.subi %[[VAL_131]], %[[VAL_5]] : index
-! CHECK:         br ^bb16(%[[VAL_133]], %[[VAL_137]] : index, index)
-! CHECK:       ^bb18:
-! CHECK:         %[[VAL_138:.*]] = fir.load %[[VAL_77]] : !fir.ref<f32>
-! CHECK:         %[[VAL_139:.*]] = fir.coordinate_of %[[VAL_27]], %[[VAL_19]] : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
-! CHECK:         %[[VAL_140:.*]] = fir.load %[[VAL_139]] : !fir.ref<f32>
-! CHECK:         %[[VAL_141:.*]] = arith.cmpf une, %[[VAL_138]], %[[VAL_140]] {{.*}} : f32
-! CHECK:         cond_br %[[VAL_141]], ^bb19, ^bb20
-! CHECK:       ^bb19:
-! CHECK:         %[[VAL_142:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
-! CHECK:         %[[VAL_143:.*]] = fir.convert %[[VAL_142]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_144:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_143]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_145:.*]] = fir.address_of(@_QQclX6D69736D617463682034) : !fir.ref<!fir.char<1,10>>
-! CHECK:         %[[VAL_146:.*]] = fir.convert %[[VAL_145]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_147:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
-! CHECK:         %[[VAL_148:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_144]], %[[VAL_146]], %[[VAL_147]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
-! CHECK:         %[[VAL_149:.*]] = fir.load %[[VAL_77]] : !fir.ref<f32>
-! CHECK:         %[[VAL_150:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_144]], %[[VAL_149]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_151:.*]] = fir.load %[[VAL_139]] : !fir.ref<f32>
-! CHECK:         %[[VAL_152:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_144]], %[[VAL_151]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_153:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_144]]) {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb20
-! CHECK:       ^bb20:
-! CHECK:         %[[VAL_154:.*]] = fir.load %[[VAL_94]] : !fir.ref<f32>
-! CHECK:         %[[VAL_155:.*]] = fir.coordinate_of %[[VAL_27]], %[[VAL_16]] : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
-! CHECK:         %[[VAL_156:.*]] = fir.load %[[VAL_155]] : !fir.ref<f32>
-! CHECK:         %[[VAL_157:.*]] = arith.cmpf une, %[[VAL_154]], %[[VAL_156]] {{.*}} : f32
-! CHECK:         cond_br %[[VAL_157]], ^bb21, ^bb22
-! CHECK:       ^bb21:
-! CHECK:         %[[VAL_158:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
-! CHECK:         %[[VAL_159:.*]] = fir.convert %[[VAL_158]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_160:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_159]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_161:.*]] = fir.address_of(@_QQclX6D69736D617463682035) : !fir.ref<!fir.char<1,10>>
-! CHECK:         %[[VAL_162:.*]] = fir.convert %[[VAL_161]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_163:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
-! CHECK:         %[[VAL_164:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_160]], %[[VAL_162]], %[[VAL_163]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
-! CHECK:         %[[VAL_165:.*]] = fir.load %[[VAL_94]] : !fir.ref<f32>
-! CHECK:         %[[VAL_166:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_160]], %[[VAL_165]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_167:.*]] = fir.load %[[VAL_155]] : !fir.ref<f32>
-! CHECK:         %[[VAL_168:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_160]], %[[VAL_167]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_169:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_160]]) {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb22
-! CHECK:       ^bb22:
-! CHECK:         %[[VAL_170:.*]] = fir.load %[[VAL_111]] : !fir.ref<f32>
-! CHECK:         %[[VAL_171:.*]] = fir.coordinate_of %[[VAL_27]], %[[VAL_8]] : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
-! CHECK:         %[[VAL_172:.*]] = fir.load %[[VAL_171]] : !fir.ref<f32>
-! CHECK:         %[[VAL_173:.*]] = arith.cmpf une, %[[VAL_170]], %[[VAL_172]] {{.*}} : f32
-! CHECK:         cond_br %[[VAL_173]], ^bb23, ^bb24
-! CHECK:       ^bb23:
-! CHECK:         %[[VAL_174:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
-! CHECK:         %[[VAL_175:.*]] = fir.convert %[[VAL_174]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_176:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_175]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_177:.*]] = fir.address_of(@_QQclX6D69736D617463682036) : !fir.ref<!fir.char<1,10>>
-! CHECK:         %[[VAL_178:.*]] = fir.convert %[[VAL_177]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_179:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
-! CHECK:         %[[VAL_180:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_176]], %[[VAL_178]], %[[VAL_179]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
-! CHECK:         %[[VAL_181:.*]] = fir.load %[[VAL_111]] : !fir.ref<f32>
-! CHECK:         %[[VAL_182:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_176]], %[[VAL_181]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_183:.*]] = fir.load %[[VAL_171]] : !fir.ref<f32>
-! CHECK:         %[[VAL_184:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_176]], %[[VAL_183]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_185:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_176]]) {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb24
-! CHECK:       ^bb24:
-! CHECK:         %[[VAL_186:.*]] = fir.address_of(@_QQro.3xi4.0) : !fir.ref<!fir.array<3xi32>>
-! CHECK:         br ^bb25(%[[VAL_6]], %[[VAL_11]] : index, index)
-! CHECK:       ^bb25(%[[VAL_187:.*]]: index, %[[VAL_188:.*]]: index):
-! CHECK:         %[[VAL_189:.*]] = arith.cmpi sgt, %[[VAL_188]], %[[VAL_6]] : index
-! CHECK:         cond_br %[[VAL_189]], ^bb26, ^bb27
-! CHECK:       ^bb26:
-! CHECK:         %[[VAL_190:.*]] = arith.addi %[[VAL_187]], %[[VAL_5]] : index
-! CHECK:         %[[VAL_191:.*]] = fir.array_coor %[[VAL_186]](%[[VAL_65]]) %[[VAL_190]] : (!fir.ref<!fir.array<3xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
-! CHECK:         %[[VAL_192:.*]] = fir.load %[[VAL_191]] : !fir.ref<i32>
-! CHECK:         %[[VAL_193:.*]] = fir.array_coor %[[VAL_29]](%[[VAL_65]]) %[[VAL_190]] : (!fir.ref<!fir.array<3xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
-! CHECK:         fir.store %[[VAL_192]] to %[[VAL_193]] : !fir.ref<i32>
-! CHECK:         %[[VAL_194:.*]] = arith.subi %[[VAL_188]], %[[VAL_5]] : index
-! CHECK:         br ^bb25(%[[VAL_190]], %[[VAL_194]] : index, index)
-! CHECK:       ^bb27:
-! CHECK:         %[[VAL_195:.*]] = fir.allocmem !fir.array<3xf32>
-! CHECK:         br ^bb28(%[[VAL_6]], %[[VAL_11]] : index, index)
-! CHECK:       ^bb28(%[[VAL_196:.*]]: index, %[[VAL_197:.*]]: index):
-! CHECK:         %[[VAL_198:.*]] = arith.cmpi sgt, %[[VAL_197]], %[[VAL_6]] : index
-! CHECK:         cond_br %[[VAL_198]], ^bb29, ^bb30
-! CHECK:       ^bb29:
-! CHECK:         %[[VAL_199:.*]] = arith.addi %[[VAL_196]], %[[VAL_5]] : index
-! CHECK:         %[[VAL_200:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_65]]) %[[VAL_199]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:         %[[VAL_201:.*]] = fir.array_coor %[[VAL_195]](%[[VAL_65]]) %[[VAL_199]] : (!fir.heap<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:         %[[VAL_202:.*]] = fir.load %[[VAL_200]] : !fir.ref<f32>
-! CHECK:         fir.store %[[VAL_202]] to %[[VAL_201]] : !fir.ref<f32>
-! CHECK:         %[[VAL_203:.*]] = arith.subi %[[VAL_197]], %[[VAL_5]] : index
-! CHECK:         br ^bb28(%[[VAL_199]], %[[VAL_203]] : index, index)
-! CHECK:       ^bb30(%[[VAL_205:.*]]: index, %[[VAL_206:.*]]: index):
-! CHECK:         %[[VAL_207:.*]] = arith.cmpi sgt, %[[VAL_206]], %[[VAL_6]] : index
-! CHECK:         cond_br %[[VAL_207]], ^bb31, ^bb32(%[[VAL_6]], %[[VAL_11]] : index, index)
-! CHECK:       ^bb31:
-! CHECK:         %[[VAL_208:.*]] = arith.addi %[[VAL_205]], %[[VAL_5]] : index
-! CHECK:         %[[VAL_209:.*]] = fir.array_coor %[[VAL_29]](%[[VAL_65]]) %[[VAL_208]] : (!fir.ref<!fir.array<3xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
-! CHECK:         %[[VAL_210:.*]] = fir.load %[[VAL_209]] : !fir.ref<i32>
-! CHECK:         %[[VAL_211:.*]] = fir.convert %[[VAL_210]] : (i32) -> index
-! CHECK:         %[[VAL_212:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_65]]) %[[VAL_211]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:         %[[VAL_213:.*]] = fir.load %[[VAL_212]] : !fir.ref<f32>
-! CHECK:         %[[VAL_214:.*]] = fir.array_coor %[[VAL_195]](%[[VAL_65]]) %[[VAL_208]] : (!fir.heap<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:         fir.store %[[VAL_213]] to %[[VAL_214]] : !fir.ref<f32>
-! CHECK:         %[[VAL_215:.*]] = arith.subi %[[VAL_206]], %[[VAL_5]] : index
-! CHECK:         br ^bb30(%[[VAL_208]], %[[VAL_215]] : index, index)
-! CHECK:       ^bb32(%[[VAL_216:.*]]: index, %[[VAL_217:.*]]: index):
-! CHECK:         %[[VAL_218:.*]] = arith.cmpi sgt, %[[VAL_217]], %[[VAL_6]] : index
-! CHECK:         cond_br %[[VAL_218]], ^bb33, ^bb34
-! CHECK:       ^bb33:
-! CHECK:         %[[VAL_219:.*]] = arith.addi %[[VAL_216]], %[[VAL_5]] : index
-! CHECK:         %[[VAL_220:.*]] = fir.array_coor %[[VAL_195]](%[[VAL_65]]) %[[VAL_219]] : (!fir.heap<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:         %[[VAL_221:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_65]]) %[[VAL_219]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:         %[[VAL_222:.*]] = fir.load %[[VAL_220]] : !fir.ref<f32>
-! CHECK:         fir.store %[[VAL_222]] to %[[VAL_221]] : !fir.ref<f32>
-! CHECK:         %[[VAL_223:.*]] = arith.subi %[[VAL_217]], %[[VAL_5]] : index
-! CHECK:         br ^bb32(%[[VAL_219]], %[[VAL_223]] : index, index)
-! CHECK:       ^bb34:
-! CHECK:         fir.freemem %[[VAL_195]] : !fir.heap<!fir.array<3xf32>>
-! CHECK:         %[[VAL_224:.*]] = fir.load %[[VAL_77]] : !fir.ref<f32>
-! CHECK:         %[[VAL_225:.*]] = fir.load %[[VAL_96]] : !fir.ref<f32>
-! CHECK:         %[[VAL_226:.*]] = arith.cmpf une, %[[VAL_224]], %[[VAL_225]] {{.*}} : f32
-! CHECK:         cond_br %[[VAL_226]], ^bb35, ^bb36
-! CHECK:       ^bb35:
-! CHECK:         %[[VAL_227:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
-! CHECK:         %[[VAL_228:.*]] = fir.convert %[[VAL_227]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_229:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_228]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_230:.*]] = fir.address_of(@_QQclX6D69736D617463682037) : !fir.ref<!fir.char<1,10>>
-! CHECK:         %[[VAL_231:.*]] = fir.convert %[[VAL_230]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_232:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
-! CHECK:         %[[VAL_233:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_229]], %[[VAL_231]], %[[VAL_232]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
-! CHECK:         %[[VAL_234:.*]] = fir.load %[[VAL_77]] : !fir.ref<f32>
-! CHECK:         %[[VAL_235:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_229]], %[[VAL_234]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_236:.*]] = fir.load %[[VAL_96]] : !fir.ref<f32>
-! CHECK:         %[[VAL_237:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_229]], %[[VAL_236]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_238:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_229]]) {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb36
-! CHECK:       ^bb36:
-! CHECK:         %[[VAL_239:.*]] = fir.load %[[VAL_94]] : !fir.ref<f32>
-! CHECK:         %[[VAL_240:.*]] = fir.load %[[VAL_113]] : !fir.ref<f32>
-! CHECK:         %[[VAL_241:.*]] = arith.cmpf une, %[[VAL_239]], %[[VAL_240]] {{.*}} : f32
-! CHECK:         cond_br %[[VAL_241]], ^bb37, ^bb38
-! CHECK:       ^bb37:
-! CHECK:         %[[VAL_242:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
-! CHECK:         %[[VAL_243:.*]] = fir.convert %[[VAL_242]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_244:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_243]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_245:.*]] = fir.address_of(@_QQclX6D69736D617463682038) : !fir.ref<!fir.char<1,10>>
-! CHECK:         %[[VAL_246:.*]] = fir.convert %[[VAL_245]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_247:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
-! CHECK:         %[[VAL_248:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_244]], %[[VAL_246]], %[[VAL_247]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
-! CHECK:         %[[VAL_249:.*]] = fir.load %[[VAL_94]] : !fir.ref<f32>
-! CHECK:         %[[VAL_250:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_244]], %[[VAL_249]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_251:.*]] = fir.load %[[VAL_113]] : !fir.ref<f32>
-! CHECK:         %[[VAL_252:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_244]], %[[VAL_251]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_253:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_244]]) {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb38
-! CHECK:       ^bb38:
-! CHECK:         %[[VAL_254:.*]] = fir.load %[[VAL_111]] : !fir.ref<f32>
-! CHECK:         %[[VAL_255:.*]] = fir.load %[[VAL_79]] : !fir.ref<f32>
-! CHECK:         %[[VAL_256:.*]] = arith.cmpf une, %[[VAL_254]], %[[VAL_255]] {{.*}} : f32
-! CHECK:         cond_br %[[VAL_256]], ^bb39, ^bb40
-! CHECK:       ^bb39:
-! CHECK:         %[[VAL_257:.*]] = fir.address_of(@_QQclX{{.*}}) : !fir.ref<!fir.char<1,
-! CHECK:         %[[VAL_258:.*]] = fir.convert %[[VAL_257]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_259:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_18]], %[[VAL_258]], %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:         %[[VAL_260:.*]] = fir.address_of(@_QQclX6D69736D617463682039) : !fir.ref<!fir.char<1,10>>
-! CHECK:         %[[VAL_261:.*]] = fir.convert %[[VAL_260]] : (!fir.ref<!fir.char<1,10>>) -> !fir.ref<i8>
-! CHECK:         %[[VAL_262:.*]] = fir.convert %[[VAL_0]] : (index) -> i64
-! CHECK:         %[[VAL_263:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_259]], %[[VAL_261]], %[[VAL_262]]) {{.*}}: (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
-! CHECK:         %[[VAL_264:.*]] = fir.load %[[VAL_111]] : !fir.ref<f32>
-! CHECK:         %[[VAL_265:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_259]], %[[VAL_264]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_266:.*]] = fir.load %[[VAL_79]] : !fir.ref<f32>
-! CHECK:         %[[VAL_267:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_259]], %[[VAL_266]]) {{.*}}: (!fir.ref<i8>, f32) -> i1
-! CHECK:         %[[VAL_268:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_259]]) {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:         br ^bb40
-! CHECK:       ^bb40:
-! CHECK:         return
-! CHECK:       }
+! CHECK-LABEL:   func.func @_QQmain() attributes {fir.bindc_name = "p"} {
+! CHECK-DAG:           %[[VAL_0:.*]] = arith.constant 8 : i64
+! CHECK-DAG:           %[[VAL_1:.*]] = arith.constant 2 : i64
+! CHECK-DAG:           %[[VAL_2:.*]] = arith.constant 7 : i64
+! CHECK-DAG:           %[[VAL_3:.*]] = arith.constant 0 : i64
+! CHECK-DAG:           %[[VAL_4:.*]] = arith.constant 3 : i64
+! CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 2 : index
+! CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 4 : index
+! CHECK-DAG:           %[[VAL_7:.*]] = arith.constant {{[0-9]+}} : i32
+! CHECK-DAG:           %[[VAL_8:.*]] = arith.constant {{[0-9]+}} : i32
+! CHECK-DAG:           %[[VAL_9:.*]] = arith.constant {{[0-9]+}} : i32
+! CHECK-DAG:           %[[VAL_10:.*]] = arith.constant {{[0-9]+}} : i32
+! CHECK-DAG:           %[[VAL_11:.*]] = arith.constant {{[0-9]+}} : i32
+! CHECK-DAG:           %[[VAL_12:.*]] = arith.constant {{[0-9]+}} : i32
+! CHECK-DAG:           %[[VAL_13:.*]] = arith.constant {{[0-9]+}} : i32
+! CHECK-DAG:           %[[VAL_14:.*]] = arith.constant {{[0-9]+}} : i32
+! CHECK-DAG:           %[[VAL_15:.*]] = arith.constant {{[0-9]+}} : i32
+! CHECK-DAG:           %[[VAL_16:.*]] = arith.constant 6 : i32
+! CHECK-DAG:           %[[VAL_17:.*]] = arith.constant 0 : index
+! CHECK-DAG:           %[[VAL_18:.*]] = arith.constant 4 : i64
+! CHECK-DAG:           %[[VAL_19:.*]] = arith.constant 1 : i64
+! CHECK-DAG:           %[[VAL_20:.*]] = arith.constant 1 : index
+! CHECK-DAG:           %[[VAL_21:.*]] = arith.constant 1 : i32
+! CHECK-DAG:           %[[VAL_22:.*]] = arith.constant 0 : i32
+! CHECK-DAG:           %[[VAL_23:.*]] = arith.constant 3 : index
+! CHECK-DAG:           %[[VAL_24:.*]] = arith.constant 10 : index
+! CHECK-DAG:           %[[VAL_25:.*]] = fir.address_of(@_QFEa1) : !fir.ref<!fir.array<10x10xf32>>
+! CHECK-DAG:           %[[VAL_26:.*]] = fir.alloca !fir.array<3xf32> {bindc_name = "a2", uniq_name = "_QFEa2"}
+! CHECK-DAG:           %[[VAL_27:.*]] = fir.address_of(@_QFEa3) : !fir.ref<!fir.array<10xf32>>
+! CHECK-DAG:           %[[VAL_28:.*]] = fir.alloca i32 {bindc_name = "i", uniq_name = "_QFEi"}
+! CHECK-DAG:           %[[VAL_29:.*]] = fir.alloca !fir.array<3xi32> {bindc_name = "iv", uniq_name = "_QFEiv"}
+! CHECK-DAG:           %[[VAL_30:.*]] = fir.alloca i32 {bindc_name = "j", uniq_name = "_QFEj"}
+! CHECK-DAG:           %[[VAL_31:.*]] = fir.alloca i32 {bindc_name = "k", uniq_name = "_QFEk"}
+! CHECK:           fir.store %[[VAL_22]] to %[[VAL_31]] : !fir.ref<i32>
+! CHECK:           %[[VAL_32:.*]] = fir.convert %[[VAL_20]] : (index) -> i32
+! CHECK:           cf.br ^bb1(%[[VAL_32]], %[[VAL_24]] : i32, index)
+! CHECK:         ^bb1(%[[VAL_33:.*]]: i32, %[[VAL_34:.*]]: index):
+! CHECK:           %[[VAL_35:.*]] = arith.cmpi sgt, %[[VAL_34]], %[[VAL_17]] : index
+! CHECK:           cf.cond_br %[[VAL_35]], ^bb2, ^bb6
+! CHECK:         ^bb2:
+! CHECK:           fir.store %[[VAL_33]] to %[[VAL_30]] : !fir.ref<i32>
+! CHECK:           cf.br ^bb3(%[[VAL_32]], %[[VAL_24]] : i32, index)
+! CHECK:         ^bb3(%[[VAL_36:.*]]: i32, %[[VAL_37:.*]]: index):
+! CHECK:           %[[VAL_38:.*]] = arith.cmpi sgt, %[[VAL_37]], %[[VAL_17]] : index
+! CHECK:           cf.cond_br %[[VAL_38]], ^bb4, ^bb5
+! CHECK:         ^bb4:
+! CHECK:           fir.store %[[VAL_36]] to %[[VAL_28]] : !fir.ref<i32>
+! CHECK:           %[[VAL_39:.*]] = fir.load %[[VAL_31]] : !fir.ref<i32>
+! CHECK:           %[[VAL_40:.*]] = arith.addi %[[VAL_39]], %[[VAL_21]] : i32
+! CHECK:           fir.store %[[VAL_40]] to %[[VAL_31]] : !fir.ref<i32>
+! CHECK:           %[[VAL_41:.*]] = fir.load %[[VAL_31]] : !fir.ref<i32>
+! CHECK:           %[[VAL_42:.*]] = fir.convert %[[VAL_41]] : (i32) -> f32
+! CHECK:           %[[VAL_43:.*]] = fir.call @fir.cos.contract.f32.f32(%[[VAL_42]]) fastmath<contract> : (f32) -> f32
+! CHECK:           %[[VAL_44:.*]] = fir.load %[[VAL_28]] : !fir.ref<i32>
+! CHECK:           %[[VAL_45:.*]] = fir.convert %[[VAL_44]] : (i32) -> i64
+! CHECK:           %[[VAL_46:.*]] = arith.subi %[[VAL_45]], %[[VAL_19]] : i64
+! CHECK:           %[[VAL_47:.*]] = fir.load %[[VAL_30]] : !fir.ref<i32>
+! CHECK:           %[[VAL_48:.*]] = fir.convert %[[VAL_47]] : (i32) -> i64
+! CHECK:           %[[VAL_49:.*]] = arith.subi %[[VAL_48]], %[[VAL_19]] : i64
+! CHECK:           %[[VAL_50:.*]] = fir.coordinate_of %[[VAL_25]], %[[VAL_46]], %[[VAL_49]] : (!fir.ref<!fir.array<10x10xf32>>, i64, i64) -> !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_43]] to %[[VAL_50]] : !fir.ref<f32>
+! CHECK:           %[[VAL_51:.*]] = fir.load %[[VAL_28]] : !fir.ref<i32>
+! CHECK:           %[[VAL_52:.*]] = arith.addi %[[VAL_51]], %[[VAL_32]] : i32
+! CHECK:           %[[VAL_53:.*]] = arith.subi %[[VAL_37]], %[[VAL_20]] : index
+! CHECK:           cf.br ^bb3(%[[VAL_52]], %[[VAL_53]] : i32, index)
+! CHECK:         ^bb5:
+! CHECK:           fir.store %[[VAL_36]] to %[[VAL_28]] : !fir.ref<i32>
+! CHECK:           %[[VAL_54:.*]] = fir.load %[[VAL_31]] : !fir.ref<i32>
+! CHECK:           %[[VAL_55:.*]] = fir.convert %[[VAL_54]] : (i32) -> f32
+! CHECK:           %[[VAL_56:.*]] = fir.call @fir.sin.contract.f32.f32(%[[VAL_55]]) fastmath<contract> : (f32) -> f32
+! CHECK:           %[[VAL_57:.*]] = fir.load %[[VAL_30]] : !fir.ref<i32>
+! CHECK:           %[[VAL_58:.*]] = fir.convert %[[VAL_57]] : (i32) -> i64
+! CHECK:           %[[VAL_59:.*]] = arith.subi %[[VAL_58]], %[[VAL_19]] : i64
+! CHECK:           %[[VAL_60:.*]] = fir.coordinate_of %[[VAL_27]], %[[VAL_59]] : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_56]] to %[[VAL_60]] : !fir.ref<f32>
+! CHECK:           %[[VAL_61:.*]] = fir.load %[[VAL_30]] : !fir.ref<i32>
+! CHECK:           %[[VAL_62:.*]] = arith.addi %[[VAL_61]], %[[VAL_32]] : i32
+! CHECK:           %[[VAL_63:.*]] = arith.subi %[[VAL_34]], %[[VAL_20]] : index
+! CHECK:           cf.br ^bb1(%[[VAL_62]], %[[VAL_63]] : i32, index)
+! CHECK:         ^bb6:
+! CHECK:           fir.store %[[VAL_33]] to %[[VAL_30]] : !fir.ref<i32>
+! CHECK:           %[[VAL_64:.*]] = fir.shape %[[VAL_23]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_65:.*]] = fir.undefined index
+! CHECK:           %[[VAL_66:.*]] = fir.shape %[[VAL_24]], %[[VAL_24]] : (index, index) -> !fir.shape<2>
+! CHECK:           %[[VAL_67:.*]] = fir.slice %[[VAL_18]], %[[VAL_65]], %[[VAL_65]], %[[VAL_5]], %[[VAL_24]], %[[VAL_23]] : (i64, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:           cf.br ^bb7(%[[VAL_17]], %[[VAL_23]] : index, index)
+! CHECK:         ^bb7(%[[VAL_68:.*]]: index, %[[VAL_69:.*]]: index):
+! CHECK:           %[[VAL_70:.*]] = arith.cmpi sgt, %[[VAL_69]], %[[VAL_17]] : index
+! CHECK:           cf.cond_br %[[VAL_70]], ^bb8, ^bb9
+! CHECK:         ^bb8:
+! CHECK:           %[[VAL_71:.*]] = arith.addi %[[VAL_68]], %[[VAL_20]] : index
+! CHECK:           %[[VAL_72:.*]] = fir.array_coor %[[VAL_25]](%[[VAL_66]]) {{\[}}%[[VAL_67]]] %[[VAL_6]], %[[VAL_71]] : (!fir.ref<!fir.array<10x10xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_73:.*]] = fir.load %[[VAL_72]] : !fir.ref<f32>
+! CHECK:           %[[VAL_74:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_64]]) %[[VAL_71]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_73]] to %[[VAL_74]] : !fir.ref<f32>
+! CHECK:           %[[VAL_75:.*]] = arith.subi %[[VAL_69]], %[[VAL_20]] : index
+! CHECK:           cf.br ^bb7(%[[VAL_71]], %[[VAL_75]] : index, index)
+! CHECK:         ^bb9:
+! CHECK:           %[[VAL_76:.*]] = fir.coordinate_of %[[VAL_25]], %[[VAL_4]], %[[VAL_19]] : (!fir.ref<!fir.array<10x10xf32>>, i64, i64) -> !fir.ref<f32>
+! CHECK:           %[[VAL_77:.*]] = fir.load %[[VAL_76]] : !fir.ref<f32>
+! CHECK:           %[[VAL_78:.*]] = fir.coordinate_of %[[VAL_26]], %[[VAL_3]] : (!fir.ref<!fir.array<3xf32>>, i64) -> !fir.ref<f32>
+! CHECK:           %[[VAL_79:.*]] = fir.load %[[VAL_78]] : !fir.ref<f32>
+! CHECK:           %[[VAL_80:.*]] = arith.cmpf une, %[[VAL_77]], %[[VAL_79]] fastmath<contract> : f32
+! CHECK:           cf.cond_br %[[VAL_80]], ^bb10, ^bb11
+! CHECK:         ^bb10:
+! CHECK:           %[[VAL_81:.*]] = fir.address_of(@_QQclX3bee04f64cc15c75e483e8463401fb13) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_82:.*]] = fir.convert %[[VAL_81]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_83:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_16]], %[[VAL_82]], %[[VAL_15]]) {{.+}} (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_84:.*]] = fir.address_of(@_QQclX6D69736D617463682031) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_85:.*]] = fir.convert %[[VAL_84]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_86:.*]] = fir.convert %[[VAL_24]] : (index) -> i64
+! CHECK:           %[[VAL_87:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_83]], %[[VAL_85]], %[[VAL_86]]) {{.+}} (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:           %[[VAL_88:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_83]], %[[VAL_79]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_89:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_83]], %[[VAL_77]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_90:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_83]]) {{.+}} (!fir.ref<i8>) -> i32
+! CHECK:           cf.br ^bb11
+! CHECK:         ^bb11:
+! CHECK:           %[[VAL_91:.*]] = fir.coordinate_of %[[VAL_25]], %[[VAL_4]], %[[VAL_18]] : (!fir.ref<!fir.array<10x10xf32>>, i64, i64) -> !fir.ref<f32>
+! CHECK:           %[[VAL_92:.*]] = fir.load %[[VAL_91]] : !fir.ref<f32>
+! CHECK:           %[[VAL_93:.*]] = fir.coordinate_of %[[VAL_26]], %[[VAL_19]] : (!fir.ref<!fir.array<3xf32>>, i64) -> !fir.ref<f32>
+! CHECK:           %[[VAL_94:.*]] = fir.load %[[VAL_93]] : !fir.ref<f32>
+! CHECK:           %[[VAL_95:.*]] = arith.cmpf une, %[[VAL_92]], %[[VAL_94]] fastmath<contract> : f32
+! CHECK:           cf.cond_br %[[VAL_95]], ^bb12, ^bb13
+! CHECK:         ^bb12:
+! CHECK:           %[[VAL_96:.*]] = fir.address_of(@_QQclX3bee04f64cc15c75e483e8463401fb13) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_97:.*]] = fir.convert %[[VAL_96]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_98:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_16]], %[[VAL_97]], %[[VAL_14]]) {{.+}} (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_99:.*]] = fir.address_of(@_QQclX6D69736D617463682032) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_100:.*]] = fir.convert %[[VAL_99]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_101:.*]] = fir.convert %[[VAL_24]] : (index) -> i64
+! CHECK:           %[[VAL_102:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_98]], %[[VAL_100]], %[[VAL_101]]) {{.+}} (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:           %[[VAL_103:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_98]], %[[VAL_94]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_104:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_98]], %[[VAL_92]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_105:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_98]]) {{.+}} (!fir.ref<i8>) -> i32
+! CHECK:           cf.br ^bb13
+! CHECK:         ^bb13:
+! CHECK:           %[[VAL_106:.*]] = fir.coordinate_of %[[VAL_25]], %[[VAL_4]], %[[VAL_2]] : (!fir.ref<!fir.array<10x10xf32>>, i64, i64) -> !fir.ref<f32>
+! CHECK:           %[[VAL_107:.*]] = fir.load %[[VAL_106]] : !fir.ref<f32>
+! CHECK:           %[[VAL_108:.*]] = fir.coordinate_of %[[VAL_26]], %[[VAL_1]] : (!fir.ref<!fir.array<3xf32>>, i64) -> !fir.ref<f32>
+! CHECK:           %[[VAL_109:.*]] = fir.load %[[VAL_108]] : !fir.ref<f32>
+! CHECK:           %[[VAL_110:.*]] = arith.cmpf une, %[[VAL_107]], %[[VAL_109]] fastmath<contract> : f32
+! CHECK:           cf.cond_br %[[VAL_110]], ^bb14, ^bb15
+! CHECK:         ^bb14:
+! CHECK:           %[[VAL_111:.*]] = fir.address_of(@_QQclX3bee04f64cc15c75e483e8463401fb13) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_112:.*]] = fir.convert %[[VAL_111]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_113:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_16]], %[[VAL_112]], %[[VAL_13]]) {{.+}} (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_114:.*]] = fir.address_of(@_QQclX6D69736D617463682033) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_115:.*]] = fir.convert %[[VAL_114]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_116:.*]] = fir.convert %[[VAL_24]] : (index) -> i64
+! CHECK:           %[[VAL_117:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_113]], %[[VAL_115]], %[[VAL_116]]) {{.+}} (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:           %[[VAL_118:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_113]], %[[VAL_109]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_119:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_113]], %[[VAL_107]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_120:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_113]]) {{.+}} (!fir.ref<i8>) -> i32
+! CHECK:           cf.br ^bb15
+! CHECK:         ^bb15:
+! CHECK:           %[[VAL_121:.*]] = fir.shape %[[VAL_24]] : (index) -> !fir.shape<1>
+! CHECK:           %[[VAL_122:.*]] = fir.slice %[[VAL_20]], %[[VAL_24]], %[[VAL_6]] : (index, index, index) -> !fir.slice<1>
+! CHECK:           cf.br ^bb16(%[[VAL_17]], %[[VAL_23]] : index, index)
+! CHECK:         ^bb16(%[[VAL_123:.*]]: index, %[[VAL_124:.*]]: index):
+! CHECK:           %[[VAL_125:.*]] = arith.cmpi sgt, %[[VAL_124]], %[[VAL_17]] : index
+! CHECK:           cf.cond_br %[[VAL_125]], ^bb17, ^bb18
+! CHECK:         ^bb17:
+! CHECK:           %[[VAL_126:.*]] = arith.addi %[[VAL_123]], %[[VAL_20]] : index
+! CHECK:           %[[VAL_127:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_64]]) %[[VAL_126]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_128:.*]] = fir.load %[[VAL_127]] : !fir.ref<f32>
+! CHECK:           %[[VAL_129:.*]] = fir.array_coor %[[VAL_27]](%[[VAL_121]]) {{\[}}%[[VAL_122]]] %[[VAL_126]] : (!fir.ref<!fir.array<10xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_128]] to %[[VAL_129]] : !fir.ref<f32>
+! CHECK:           %[[VAL_130:.*]] = arith.subi %[[VAL_124]], %[[VAL_20]] : index
+! CHECK:           cf.br ^bb16(%[[VAL_126]], %[[VAL_130]] : index, index)
+! CHECK:         ^bb18:
+! CHECK:           %[[VAL_131:.*]] = fir.coordinate_of %[[VAL_27]], %[[VAL_3]] : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+! CHECK:           %[[VAL_132:.*]] = fir.load %[[VAL_131]] : !fir.ref<f32>
+! CHECK:           %[[VAL_133:.*]] = arith.cmpf une, %[[VAL_77]], %[[VAL_132]] fastmath<contract> : f32
+! CHECK:           cf.cond_br %[[VAL_133]], ^bb19, ^bb20
+! CHECK:         ^bb19:
+! CHECK:           %[[VAL_134:.*]] = fir.address_of(@_QQclX3bee04f64cc15c75e483e8463401fb13) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_135:.*]] = fir.convert %[[VAL_134]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_136:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_16]], %[[VAL_135]], %[[VAL_12]]) {{.+}} (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_137:.*]] = fir.address_of(@_QQclX6D69736D617463682034) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_138:.*]] = fir.convert %[[VAL_137]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_139:.*]] = fir.convert %[[VAL_24]] : (index) -> i64
+! CHECK:           %[[VAL_140:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_136]], %[[VAL_138]], %[[VAL_139]]) {{.+}} (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:           %[[VAL_141:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_136]], %[[VAL_77]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_142:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_136]], %[[VAL_132]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_143:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_136]]) {{.+}} (!fir.ref<i8>) -> i32
+! CHECK:           cf.br ^bb20
+! CHECK:         ^bb20:
+! CHECK:           %[[VAL_144:.*]] = fir.coordinate_of %[[VAL_27]], %[[VAL_18]] : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+! CHECK:           %[[VAL_145:.*]] = fir.load %[[VAL_144]] : !fir.ref<f32>
+! CHECK:           %[[VAL_146:.*]] = arith.cmpf une, %[[VAL_92]], %[[VAL_145]] fastmath<contract> : f32
+! CHECK:           cf.cond_br %[[VAL_146]], ^bb21, ^bb22
+! CHECK:         ^bb21:
+! CHECK:           %[[VAL_147:.*]] = fir.address_of(@_QQclX3bee04f64cc15c75e483e8463401fb13) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_148:.*]] = fir.convert %[[VAL_147]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_149:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_16]], %[[VAL_148]], %[[VAL_11]]) {{.+}} (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_150:.*]] = fir.address_of(@_QQclX6D69736D617463682035) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_151:.*]] = fir.convert %[[VAL_150]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_152:.*]] = fir.convert %[[VAL_24]] : (index) -> i64
+! CHECK:           %[[VAL_153:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_149]], %[[VAL_151]], %[[VAL_152]]) {{.+}} (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:           %[[VAL_154:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_149]], %[[VAL_92]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_155:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_149]], %[[VAL_145]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_156:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_149]]) {{.+}} (!fir.ref<i8>) -> i32
+! CHECK:           cf.br ^bb22
+! CHECK:         ^bb22:
+! CHECK:           %[[VAL_157:.*]] = fir.coordinate_of %[[VAL_27]], %[[VAL_0]] : (!fir.ref<!fir.array<10xf32>>, i64) -> !fir.ref<f32>
+! CHECK:           %[[VAL_158:.*]] = fir.load %[[VAL_157]] : !fir.ref<f32>
+! CHECK:           %[[VAL_159:.*]] = arith.cmpf une, %[[VAL_107]], %[[VAL_158]] fastmath<contract> : f32
+! CHECK:           cf.cond_br %[[VAL_159]], ^bb23, ^bb24
+! CHECK:         ^bb23:
+! CHECK:           %[[VAL_160:.*]] = fir.address_of(@_QQclX3bee04f64cc15c75e483e8463401fb13) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_161:.*]] = fir.convert %[[VAL_160]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_162:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_16]], %[[VAL_161]], %[[VAL_10]]) {{.+}} (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_163:.*]] = fir.address_of(@_QQclX6D69736D617463682036) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_164:.*]] = fir.convert %[[VAL_163]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_165:.*]] = fir.convert %[[VAL_24]] : (index) -> i64
+! CHECK:           %[[VAL_166:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_162]], %[[VAL_164]], %[[VAL_165]]) {{.+}} (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:           %[[VAL_167:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_162]], %[[VAL_107]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_168:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_162]], %[[VAL_158]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_169:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_162]]) {{.+}} (!fir.ref<i8>) -> i32
+! CHECK:           cf.br ^bb24
+! CHECK:         ^bb24:
+! CHECK:           %[[VAL_170:.*]] = fir.address_of(@_QQro.3xi4.0) : !fir.ref<!fir.array<3xi32>>
+! CHECK:           cf.br ^bb25(%[[VAL_17]], %[[VAL_23]] : index, index)
+! CHECK:         ^bb25(%[[VAL_171:.*]]: index, %[[VAL_172:.*]]: index):
+! CHECK:           %[[VAL_173:.*]] = arith.cmpi sgt, %[[VAL_172]], %[[VAL_17]] : index
+! CHECK:           cf.cond_br %[[VAL_173]], ^bb26, ^bb27
+! CHECK:         ^bb26:
+! CHECK:           %[[VAL_174:.*]] = arith.addi %[[VAL_171]], %[[VAL_20]] : index
+! CHECK:           %[[VAL_175:.*]] = fir.array_coor %[[VAL_170]](%[[VAL_64]]) %[[VAL_174]] : (!fir.ref<!fir.array<3xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
+! CHECK:           %[[VAL_176:.*]] = fir.load %[[VAL_175]] : !fir.ref<i32>
+! CHECK:           %[[VAL_177:.*]] = fir.array_coor %[[VAL_29]](%[[VAL_64]]) %[[VAL_174]] : (!fir.ref<!fir.array<3xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
+! CHECK:           fir.store %[[VAL_176]] to %[[VAL_177]] : !fir.ref<i32>
+! CHECK:           %[[VAL_178:.*]] = arith.subi %[[VAL_172]], %[[VAL_20]] : index
+! CHECK:           cf.br ^bb25(%[[VAL_174]], %[[VAL_178]] : index, index)
+! CHECK:         ^bb27:
+! CHECK:           %[[VAL_179:.*]] = fir.allocmem !fir.array<3xf32>
+! CHECK:           cf.br ^bb28(%[[VAL_17]], %[[VAL_23]] : index, index)
+! CHECK:         ^bb28(%[[VAL_180:.*]]: index, %[[VAL_181:.*]]: index):
+! CHECK:           %[[VAL_182:.*]] = arith.cmpi sgt, %[[VAL_181]], %[[VAL_17]] : index
+! CHECK:           cf.cond_br %[[VAL_182]], ^bb29, ^bb30(%[[VAL_17]], %[[VAL_23]] : index, index)
+! CHECK:         ^bb29:
+! CHECK:           %[[VAL_183:.*]] = arith.addi %[[VAL_180]], %[[VAL_20]] : index
+! CHECK:           %[[VAL_184:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_64]]) %[[VAL_183]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_185:.*]] = fir.array_coor %[[VAL_179]](%[[VAL_64]]) %[[VAL_183]] : (!fir.heap<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_186:.*]] = fir.load %[[VAL_184]] : !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_186]] to %[[VAL_185]] : !fir.ref<f32>
+! CHECK:           %[[VAL_187:.*]] = arith.subi %[[VAL_181]], %[[VAL_20]] : index
+! CHECK:           cf.br ^bb28(%[[VAL_183]], %[[VAL_187]] : index, index)
+! CHECK:         ^bb30(%[[VAL_188:.*]]: index, %[[VAL_189:.*]]: index):
+! CHECK:           %[[VAL_190:.*]] = arith.cmpi sgt, %[[VAL_189]], %[[VAL_17]] : index
+! CHECK:           cf.cond_br %[[VAL_190]], ^bb31, ^bb32(%[[VAL_17]], %[[VAL_23]] : index, index)
+! CHECK:         ^bb31:
+! CHECK:           %[[VAL_191:.*]] = arith.addi %[[VAL_188]], %[[VAL_20]] : index
+! CHECK:           %[[VAL_192:.*]] = fir.array_coor %[[VAL_29]](%[[VAL_64]]) %[[VAL_191]] : (!fir.ref<!fir.array<3xi32>>, !fir.shape<1>, index) -> !fir.ref<i32>
+! CHECK:           %[[VAL_193:.*]] = fir.load %[[VAL_192]] : !fir.ref<i32>
+! CHECK:           %[[VAL_194:.*]] = fir.convert %[[VAL_193]] : (i32) -> index
+! CHECK:           %[[VAL_195:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_64]]) %[[VAL_194]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_196:.*]] = fir.load %[[VAL_195]] : !fir.ref<f32>
+! CHECK:           %[[VAL_197:.*]] = fir.array_coor %[[VAL_179]](%[[VAL_64]]) %[[VAL_191]] : (!fir.heap<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_196]] to %[[VAL_197]] : !fir.ref<f32>
+! CHECK:           %[[VAL_198:.*]] = arith.subi %[[VAL_189]], %[[VAL_20]] : index
+! CHECK:           cf.br ^bb30(%[[VAL_191]], %[[VAL_198]] : index, index)
+! CHECK:         ^bb32(%[[VAL_199:.*]]: index, %[[VAL_200:.*]]: index):
+! CHECK:           %[[VAL_201:.*]] = arith.cmpi sgt, %[[VAL_200]], %[[VAL_17]] : index
+! CHECK:           cf.cond_br %[[VAL_201]], ^bb33, ^bb34
+! CHECK:         ^bb33:
+! CHECK:           %[[VAL_202:.*]] = arith.addi %[[VAL_199]], %[[VAL_20]] : index
+! CHECK:           %[[VAL_203:.*]] = fir.array_coor %[[VAL_179]](%[[VAL_64]]) %[[VAL_202]] : (!fir.heap<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_204:.*]] = fir.array_coor %[[VAL_26]](%[[VAL_64]]) %[[VAL_202]] : (!fir.ref<!fir.array<3xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_205:.*]] = fir.load %[[VAL_203]] : !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_205]] to %[[VAL_204]] : !fir.ref<f32>
+! CHECK:           %[[VAL_206:.*]] = arith.subi %[[VAL_200]], %[[VAL_20]] : index
+! CHECK:           cf.br ^bb32(%[[VAL_202]], %[[VAL_206]] : index, index)
+! CHECK:         ^bb34:
+! CHECK:           fir.freemem %[[VAL_179]] : !fir.heap<!fir.array<3xf32>>
+! CHECK:           %[[VAL_207:.*]] = arith.cmpf une, %[[VAL_77]], %[[VAL_94]] fastmath<contract> : f32
+! CHECK:           cf.cond_br %[[VAL_207]], ^bb35, ^bb36
+! CHECK:         ^bb35:
+! CHECK:           %[[VAL_208:.*]] = fir.address_of(@_QQclX3bee04f64cc15c75e483e8463401fb13) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_209:.*]] = fir.convert %[[VAL_208]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_210:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_16]], %[[VAL_209]], %[[VAL_9]]) {{.+}} (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_211:.*]] = fir.address_of(@_QQclX6D69736D617463682037) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_212:.*]] = fir.convert %[[VAL_211]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_213:.*]] = fir.convert %[[VAL_24]] : (index) -> i64
+! CHECK:           %[[VAL_214:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_210]], %[[VAL_212]], %[[VAL_213]]) {{.+}} (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:           %[[VAL_215:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_210]], %[[VAL_77]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_216:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_210]], %[[VAL_94]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_217:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_210]]) {{.+}} (!fir.ref<i8>) -> i32
+! CHECK:           cf.br ^bb36
+! CHECK:         ^bb36:
+! CHECK:           %[[VAL_218:.*]] = arith.cmpf une, %[[VAL_92]], %[[VAL_109]] fastmath<contract> : f32
+! CHECK:           cf.cond_br %[[VAL_218]], ^bb37, ^bb38
+! CHECK:         ^bb37:
+! CHECK:           %[[VAL_219:.*]] = fir.address_of(@_QQclX3bee04f64cc15c75e483e8463401fb13) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_220:.*]] = fir.convert %[[VAL_219]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_221:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_16]], %[[VAL_220]], %[[VAL_8]]) {{.+}} (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_222:.*]] = fir.address_of(@_QQclX6D69736D617463682038) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_223:.*]] = fir.convert %[[VAL_222]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_224:.*]] = fir.convert %[[VAL_24]] : (index) -> i64
+! CHECK:           %[[VAL_225:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_221]], %[[VAL_223]], %[[VAL_224]]) {{.+}} (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:           %[[VAL_226:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_221]], %[[VAL_92]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_227:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_221]], %[[VAL_109]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_228:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_221]]) {{.+}} (!fir.ref<i8>) -> i32
+! CHECK:           cf.br ^bb38
+! CHECK:         ^bb38:
+! CHECK:           %[[VAL_229:.*]] = arith.cmpf une, %[[VAL_107]], %[[VAL_79]] fastmath<contract> : f32
+! CHECK:           cf.cond_br %[[VAL_229]], ^bb39, ^bb40
+! CHECK:         ^bb39:
+! CHECK:           %[[VAL_230:.*]] = fir.address_of(@_QQclX3bee04f64cc15c75e483e8463401fb13) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_231:.*]] = fir.convert %[[VAL_230]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_232:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_16]], %[[VAL_231]], %[[VAL_7]]) {{.+}} (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_233:.*]] = fir.address_of(@_QQclX6D69736D617463682039) : !fir.ref<!fir.char<1,{{.*}}>>
+! CHECK:           %[[VAL_234:.*]] = fir.convert %[[VAL_233]] : (!fir.ref<!fir.char<1,{{.*}}>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_235:.*]] = fir.convert %[[VAL_24]] : (index) -> i64
+! CHECK:           %[[VAL_236:.*]] = fir.call @_FortranAioOutputAscii(%[[VAL_232]], %[[VAL_234]], %[[VAL_235]]) {{.+}} (!fir.ref<i8>, !fir.ref<i8>, i64) -> i1
+! CHECK:           %[[VAL_237:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_232]], %[[VAL_107]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_238:.*]] = fir.call @_FortranAioOutputReal32(%[[VAL_232]], %[[VAL_79]]) {{.+}} (!fir.ref<i8>, f32) -> i1
+! CHECK:           %[[VAL_239:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_232]]) {{.+}} (!fir.ref<i8>) -> i32
+! CHECK:           cf.br ^bb40
+! CHECK:         ^bb40:
+! CHECK:           return
+! CHECK:         }
+
 
 program p
   real :: a1(10,10)

--- a/flang/test/Lower/array-temp.f90
+++ b/flang/test/Lower/array-temp.f90
@@ -20,6 +20,340 @@ subroutine ss1
 ! print*, aa(1:2), aa(N-1:N)
 end
 
+! CHECK-LABEL:   func.func @_QPss2(
+! CHECK-SAME:                      %[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "n"}) {
+! CHECK:           %[[VAL_0:.*]] = arith.constant -1 : index
+! CHECK:           %[[VAL_1:.*]] = arith.constant 2 : index
+! CHECK:           %[[VAL_2:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_3:.*]] = arith.constant 6 : i32
+! CHECK:           %[[VAL_4:.*]] = arith.constant 7.000000e+00 : f32
+! CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_6:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_7:.*]] = arith.constant -2.000000e+00 : f32
+! CHECK:           %[[VAL_8:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_9:.*]] = fir.load %[[ARG0]] : !fir.ref<i32>
+! CHECK:           %[[VAL_10:.*]] = fir.convert %[[VAL_9]] : (i32) -> index
+! CHECK:           %[[VAL_11:.*]] = arith.cmpi sgt, %[[VAL_10]], %[[VAL_8]] : index
+! CHECK:           %[[VAL_12:.*]] = arith.select %[[VAL_11]], %[[VAL_10]], %[[VAL_8]] : index
+! CHECK:           %[[VAL_13:.*]] = fir.alloca !fir.array<?xf32>, %[[VAL_12]] {bindc_name = "aa", uniq_name = "_QFss2Eaa"}
+! CHECK:           %[[VAL_14:.*]] = fir.shape %[[VAL_12]] : (index) -> !fir.shape<1>
+! CHECK:           cf.br ^bb1(%[[VAL_8]], %[[VAL_12]] : index, index)
+! CHECK:         ^bb1(%[[VAL_15:.*]]: index, %[[VAL_16:.*]]: index):
+! CHECK:           %[[VAL_17:.*]] = arith.cmpi sgt, %[[VAL_16]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_17]], ^bb2, ^bb3
+! CHECK:         ^bb2:
+! CHECK:           %[[VAL_18:.*]] = arith.addi %[[VAL_15]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_19:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) %[[VAL_18]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_7]] to %[[VAL_19]] : !fir.ref<f32>
+! CHECK:           %[[VAL_20:.*]] = arith.subi %[[VAL_16]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb1(%[[VAL_18]], %[[VAL_20]] : index, index)
+! CHECK:         ^bb3:
+! CHECK:           %[[VAL_21:.*]] = arith.addi %[[VAL_10]], %[[VAL_0]] : index
+! CHECK:           %[[VAL_22:.*]] = arith.cmpi sgt, %[[VAL_21]], %[[VAL_8]] : index
+! CHECK:           %[[VAL_23:.*]] = arith.select %[[VAL_22]], %[[VAL_21]], %[[VAL_8]] : index
+! CHECK:           %[[VAL_24:.*]] = fir.slice %[[VAL_1]], %[[VAL_10]], %[[VAL_6]] : (index, index, index) -> !fir.slice<1>
+! CHECK:           %[[VAL_25:.*]] = fir.allocmem !fir.array<?xf32>, %[[VAL_12]]
+! CHECK:           cf.br ^bb4(%[[VAL_8]], %[[VAL_12]] : index, index)
+! CHECK:         ^bb4(%[[VAL_26:.*]]: index, %[[VAL_27:.*]]: index):
+! CHECK:           %[[VAL_28:.*]] = arith.cmpi sgt, %[[VAL_27]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_28]], ^bb5, ^bb6
+! CHECK:         ^bb5:
+! CHECK:           %[[VAL_29:.*]] = arith.addi %[[VAL_26]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_30:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) %[[VAL_29]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_31:.*]] = fir.array_coor %[[VAL_25]](%[[VAL_14]]) %[[VAL_29]] : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_32:.*]] = fir.load %[[VAL_30]] : !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_32]] to %[[VAL_31]] : !fir.ref<f32>
+! CHECK:           %[[VAL_33:.*]] = arith.subi %[[VAL_27]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb4(%[[VAL_29]], %[[VAL_33]] : index, index)
+! CHECK:         ^bb6:
+! CHECK:           %[[VAL_34:.*]] = arith.subi %[[VAL_9]], %[[VAL_5]] : i32
+! CHECK:           %[[VAL_35:.*]] = fir.convert %[[VAL_34]] : (i32) -> index
+! CHECK:           %[[VAL_36:.*]] = fir.slice %[[VAL_6]], %[[VAL_35]], %[[VAL_6]] : (index, index, index) -> !fir.slice<1>
+! CHECK:           cf.br ^bb7(%[[VAL_8]], %[[VAL_23]] : index, index)
+! CHECK:         ^bb7(%[[VAL_37:.*]]: index, %[[VAL_38:.*]]: index):
+! CHECK:           %[[VAL_39:.*]] = arith.cmpi sgt, %[[VAL_38]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_39]], ^bb8, ^bb9(%[[VAL_8]], %[[VAL_12]] : index, index)
+! CHECK:         ^bb8:
+! CHECK:           %[[VAL_40:.*]] = arith.addi %[[VAL_37]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_41:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) {{\[}}%[[VAL_36]]] %[[VAL_40]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_42:.*]] = fir.load %[[VAL_41]] : !fir.ref<f32>
+! CHECK:           %[[VAL_43:.*]] = arith.addf %[[VAL_42]], %[[VAL_4]] fastmath<contract> : f32
+! CHECK:           %[[VAL_44:.*]] = fir.array_coor %[[VAL_25]](%[[VAL_14]]) {{\[}}%[[VAL_24]]] %[[VAL_40]] : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_43]] to %[[VAL_44]] : !fir.ref<f32>
+! CHECK:           %[[VAL_45:.*]] = arith.subi %[[VAL_38]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb7(%[[VAL_40]], %[[VAL_45]] : index, index)
+! CHECK:         ^bb9(%[[VAL_46:.*]]: index, %[[VAL_47:.*]]: index):
+! CHECK:           %[[VAL_48:.*]] = arith.cmpi sgt, %[[VAL_47]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_48]], ^bb10, ^bb11
+! CHECK:         ^bb10:
+! CHECK:           %[[VAL_49:.*]] = arith.addi %[[VAL_46]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_50:.*]] = fir.array_coor %[[VAL_25]](%[[VAL_14]]) %[[VAL_49]] : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_51:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) %[[VAL_49]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_52:.*]] = fir.load %[[VAL_50]] : !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_52]] to %[[VAL_51]] : !fir.ref<f32>
+! CHECK:           %[[VAL_53:.*]] = arith.subi %[[VAL_47]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb9(%[[VAL_49]], %[[VAL_53]] : index, index)
+! CHECK:         ^bb11:
+! CHECK:           fir.freemem %[[VAL_25]] : !fir.heap<!fir.array<?xf32>>
+! CHECK:           %[[VAL_54:.*]] = fir.address_of(@_QQclX88e38683fcd4166fc29b4ce91ec570e4) : !fir.ref<!fir.char<1,80>>
+! CHECK:           %[[VAL_55:.*]] = fir.convert %[[VAL_54]] : (!fir.ref<!fir.char<1,80>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_56:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_3]], %[[VAL_55]], %[[VAL_2]]) fastmath<contract> {fir.llvm_memory = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = readwrite>, llvm.nocallback, llvm.nosync} : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_57:.*]] = fir.slice %[[VAL_6]], %[[VAL_1]], %[[VAL_6]] : (index, index, index) -> !fir.slice<1>
+! CHECK:           %[[VAL_58:.*]] = fir.embox %[[VAL_13]](%[[VAL_14]]) {{\[}}%[[VAL_57]]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<2xf32>>
+! CHECK:           %[[VAL_59:.*]] = fir.convert %[[VAL_58]] : (!fir.box<!fir.array<2xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_60:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_56]], %[[VAL_59]]) fastmath<contract> {llvm.nocallback, llvm.nosync} : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:           %[[VAL_61:.*]] = fir.slice %[[VAL_35]], %[[VAL_10]], %[[VAL_6]] : (index, index, index) -> !fir.slice<1>
+! CHECK:           %[[VAL_62:.*]] = fir.embox %[[VAL_13]](%[[VAL_14]]) {{\[}}%[[VAL_61]]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
+! CHECK:           %[[VAL_63:.*]] = fir.convert %[[VAL_62]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_64:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_56]], %[[VAL_63]]) fastmath<contract> {llvm.nocallback, llvm.nosync} : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:           %[[VAL_65:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_56]]) fastmath<contract> {fir.llvm_memory = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = readwrite>, llvm.nocallback, llvm.nosync} : (!fir.ref<i8>) -> i32
+! CHECK:           return
+! CHECK:         }
+
+! CHECK-LABEL:   func.func @_QPss3(
+! CHECK-SAME:                      %[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "n"}) {
+! CHECK:           %[[VAL_0:.*]] = arith.constant -1 : index
+! CHECK:           %[[VAL_1:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_2:.*]] = arith.constant 6 : i32
+! CHECK:           %[[VAL_3:.*]] = arith.constant 7.000000e+00 : f32
+! CHECK:           %[[VAL_4:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_5:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_6:.*]] = arith.constant -2.000000e+00 : f32
+! CHECK:           %[[VAL_7:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_8:.*]] = arith.constant 2 : index
+! CHECK:           %[[VAL_9:.*]] = fir.load %[[ARG0]] : !fir.ref<i32>
+! CHECK:           %[[VAL_10:.*]] = fir.convert %[[VAL_9]] : (i32) -> index
+! CHECK:           %[[VAL_11:.*]] = arith.cmpi sgt, %[[VAL_10]], %[[VAL_7]] : index
+! CHECK:           %[[VAL_12:.*]] = arith.select %[[VAL_11]], %[[VAL_10]], %[[VAL_7]] : index
+! CHECK:           %[[VAL_13:.*]] = fir.alloca !fir.array<2x?xf32>, %[[VAL_12]] {bindc_name = "aa", uniq_name = "_QFss3Eaa"}
+! CHECK:           %[[VAL_14:.*]] = fir.shape %[[VAL_8]], %[[VAL_12]] : (index, index) -> !fir.shape<2>
+! CHECK:           cf.br ^bb1(%[[VAL_7]], %[[VAL_12]] : index, index)
+! CHECK:         ^bb1(%[[VAL_15:.*]]: index, %[[VAL_16:.*]]: index):
+! CHECK:           %[[VAL_17:.*]] = arith.cmpi sgt, %[[VAL_16]], %[[VAL_7]] : index
+! CHECK:           cf.cond_br %[[VAL_17]], ^bb2(%[[VAL_7]], %[[VAL_8]] : index, index), ^bb5
+! CHECK:         ^bb2(%[[VAL_18:.*]]: index, %[[VAL_19:.*]]: index):
+! CHECK:           %[[VAL_20:.*]] = arith.cmpi sgt, %[[VAL_19]], %[[VAL_7]] : index
+! CHECK:           cf.cond_br %[[VAL_20]], ^bb3, ^bb4
+! CHECK:         ^bb3:
+! CHECK:           %[[VAL_21:.*]] = arith.addi %[[VAL_18]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_22:.*]] = arith.addi %[[VAL_15]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_23:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) %[[VAL_21]], %[[VAL_22]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_6]] to %[[VAL_23]] : !fir.ref<f32>
+! CHECK:           %[[VAL_24:.*]] = arith.subi %[[VAL_19]], %[[VAL_5]] : index
+! CHECK:           cf.br ^bb2(%[[VAL_21]], %[[VAL_24]] : index, index)
+! CHECK:         ^bb4:
+! CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_15]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_26:.*]] = arith.subi %[[VAL_16]], %[[VAL_5]] : index
+! CHECK:           cf.br ^bb1(%[[VAL_25]], %[[VAL_26]] : index, index)
+! CHECK:         ^bb5:
+! CHECK:           %[[VAL_27:.*]] = arith.addi %[[VAL_10]], %[[VAL_0]] : index
+! CHECK:           %[[VAL_28:.*]] = arith.cmpi sgt, %[[VAL_27]], %[[VAL_7]] : index
+! CHECK:           %[[VAL_29:.*]] = arith.select %[[VAL_28]], %[[VAL_27]], %[[VAL_7]] : index
+! CHECK:           %[[VAL_30:.*]] = fir.slice %[[VAL_5]], %[[VAL_8]], %[[VAL_5]], %[[VAL_8]], %[[VAL_10]], %[[VAL_5]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:           %[[VAL_31:.*]] = fir.allocmem !fir.array<2x?xf32>, %[[VAL_12]]
+! CHECK:           cf.br ^bb6(%[[VAL_7]], %[[VAL_12]] : index, index)
+! CHECK:         ^bb6(%[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index):
+! CHECK:           %[[VAL_34:.*]] = arith.cmpi sgt, %[[VAL_33]], %[[VAL_7]] : index
+! CHECK:           cf.cond_br %[[VAL_34]], ^bb7(%[[VAL_7]], %[[VAL_8]] : index, index), ^bb10
+! CHECK:         ^bb7(%[[VAL_35:.*]]: index, %[[VAL_36:.*]]: index):
+! CHECK:           %[[VAL_37:.*]] = arith.cmpi sgt, %[[VAL_36]], %[[VAL_7]] : index
+! CHECK:           cf.cond_br %[[VAL_37]], ^bb8, ^bb9
+! CHECK:         ^bb8:
+! CHECK:           %[[VAL_38:.*]] = arith.addi %[[VAL_35]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_39:.*]] = arith.addi %[[VAL_32]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_40:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) %[[VAL_38]], %[[VAL_39]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_41:.*]] = fir.array_coor %[[VAL_31]](%[[VAL_14]]) %[[VAL_38]], %[[VAL_39]] : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_42:.*]] = fir.load %[[VAL_40]] : !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_42]] to %[[VAL_41]] : !fir.ref<f32>
+! CHECK:           %[[VAL_43:.*]] = arith.subi %[[VAL_36]], %[[VAL_5]] : index
+! CHECK:           cf.br ^bb7(%[[VAL_38]], %[[VAL_43]] : index, index)
+! CHECK:         ^bb9:
+! CHECK:           %[[VAL_44:.*]] = arith.addi %[[VAL_32]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_45:.*]] = arith.subi %[[VAL_33]], %[[VAL_5]] : index
+! CHECK:           cf.br ^bb6(%[[VAL_44]], %[[VAL_45]] : index, index)
+! CHECK:         ^bb10:
+! CHECK:           %[[VAL_46:.*]] = arith.subi %[[VAL_9]], %[[VAL_4]] : i32
+! CHECK:           %[[VAL_47:.*]] = fir.convert %[[VAL_46]] : (i32) -> index
+! CHECK:           %[[VAL_48:.*]] = fir.slice %[[VAL_5]], %[[VAL_8]], %[[VAL_5]], %[[VAL_5]], %[[VAL_47]], %[[VAL_5]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:           cf.br ^bb11(%[[VAL_7]], %[[VAL_29]] : index, index)
+! CHECK:         ^bb11(%[[VAL_49:.*]]: index, %[[VAL_50:.*]]: index):
+! CHECK:           %[[VAL_51:.*]] = arith.cmpi sgt, %[[VAL_50]], %[[VAL_7]] : index
+! CHECK:           cf.cond_br %[[VAL_51]], ^bb12(%[[VAL_7]], %[[VAL_8]] : index, index), ^bb15(%[[VAL_7]], %[[VAL_12]] : index, index)
+! CHECK:         ^bb12(%[[VAL_52:.*]]: index, %[[VAL_53:.*]]: index):
+! CHECK:           %[[VAL_54:.*]] = arith.cmpi sgt, %[[VAL_53]], %[[VAL_7]] : index
+! CHECK:           cf.cond_br %[[VAL_54]], ^bb13, ^bb14
+! CHECK:         ^bb13:
+! CHECK:           %[[VAL_55:.*]] = arith.addi %[[VAL_52]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_56:.*]] = arith.addi %[[VAL_49]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_57:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) {{\[}}%[[VAL_48]]] %[[VAL_55]], %[[VAL_56]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_58:.*]] = fir.load %[[VAL_57]] : !fir.ref<f32>
+! CHECK:           %[[VAL_59:.*]] = arith.addf %[[VAL_58]], %[[VAL_3]] fastmath<contract> : f32
+! CHECK:           %[[VAL_60:.*]] = fir.array_coor %[[VAL_31]](%[[VAL_14]]) {{\[}}%[[VAL_30]]] %[[VAL_55]], %[[VAL_56]] : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_59]] to %[[VAL_60]] : !fir.ref<f32>
+! CHECK:           %[[VAL_61:.*]] = arith.subi %[[VAL_53]], %[[VAL_5]] : index
+! CHECK:           cf.br ^bb12(%[[VAL_55]], %[[VAL_61]] : index, index)
+! CHECK:         ^bb14:
+! CHECK:           %[[VAL_62:.*]] = arith.addi %[[VAL_49]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_63:.*]] = arith.subi %[[VAL_50]], %[[VAL_5]] : index
+! CHECK:           cf.br ^bb11(%[[VAL_62]], %[[VAL_63]] : index, index)
+! CHECK:         ^bb15(%[[VAL_64:.*]]: index, %[[VAL_65:.*]]: index):
+! CHECK:           %[[VAL_66:.*]] = arith.cmpi sgt, %[[VAL_65]], %[[VAL_7]] : index
+! CHECK:           cf.cond_br %[[VAL_66]], ^bb16(%[[VAL_7]], %[[VAL_8]] : index, index), ^bb19
+! CHECK:         ^bb16(%[[VAL_67:.*]]: index, %[[VAL_68:.*]]: index):
+! CHECK:           %[[VAL_69:.*]] = arith.cmpi sgt, %[[VAL_68]], %[[VAL_7]] : index
+! CHECK:           cf.cond_br %[[VAL_69]], ^bb17, ^bb18
+! CHECK:         ^bb17:
+! CHECK:           %[[VAL_70:.*]] = arith.addi %[[VAL_67]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_71:.*]] = arith.addi %[[VAL_64]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_72:.*]] = fir.array_coor %[[VAL_31]](%[[VAL_14]]) %[[VAL_70]], %[[VAL_71]] : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_73:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) %[[VAL_70]], %[[VAL_71]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_74:.*]] = fir.load %[[VAL_72]] : !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_74]] to %[[VAL_73]] : !fir.ref<f32>
+! CHECK:           %[[VAL_75:.*]] = arith.subi %[[VAL_68]], %[[VAL_5]] : index
+! CHECK:           cf.br ^bb16(%[[VAL_70]], %[[VAL_75]] : index, index)
+! CHECK:         ^bb18:
+! CHECK:           %[[VAL_76:.*]] = arith.addi %[[VAL_64]], %[[VAL_5]] : index
+! CHECK:           %[[VAL_77:.*]] = arith.subi %[[VAL_65]], %[[VAL_5]] : index
+! CHECK:           cf.br ^bb15(%[[VAL_76]], %[[VAL_77]] : index, index)
+! CHECK:         ^bb19:
+! CHECK:           fir.freemem %[[VAL_31]] : !fir.heap<!fir.array<2x?xf32>>
+! CHECK:           %[[VAL_78:.*]] = fir.address_of(@_QQclX88e38683fcd4166fc29b4ce91ec570e4) : !fir.ref<!fir.char<1,80>>
+! CHECK:           %[[VAL_79:.*]] = fir.convert %[[VAL_78]] : (!fir.ref<!fir.char<1,80>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_80:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_2]], %[[VAL_79]], %[[VAL_1]]) fastmath<contract> {fir.llvm_memory = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = readwrite>, llvm.nocallback, llvm.nosync} : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_81:.*]] = fir.slice %[[VAL_5]], %[[VAL_8]], %[[VAL_5]], %[[VAL_5]], %[[VAL_8]], %[[VAL_5]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:           %[[VAL_82:.*]] = fir.embox %[[VAL_13]](%[[VAL_14]]) {{\[}}%[[VAL_81]]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x2xf32>>
+! CHECK:           %[[VAL_83:.*]] = fir.convert %[[VAL_82]] : (!fir.box<!fir.array<?x2xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_84:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_80]], %[[VAL_83]]) fastmath<contract> {llvm.nocallback, llvm.nosync} : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:           %[[VAL_85:.*]] = fir.slice %[[VAL_5]], %[[VAL_8]], %[[VAL_5]], %[[VAL_47]], %[[VAL_10]], %[[VAL_5]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:           %[[VAL_86:.*]] = fir.embox %[[VAL_13]](%[[VAL_14]]) {{\[}}%[[VAL_85]]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
+! CHECK:           %[[VAL_87:.*]] = fir.convert %[[VAL_86]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_88:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_80]], %[[VAL_87]]) fastmath<contract> {llvm.nocallback, llvm.nosync} : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:           %[[VAL_89:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_80]]) fastmath<contract> {fir.llvm_memory = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = readwrite>, llvm.nocallback, llvm.nosync} : (!fir.ref<i8>) -> i32
+! CHECK:           return
+! CHECK:         }
+
+! CHECK-LABEL:   func.func @_QPss4(
+! CHECK-SAME:                      %[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "n"}) {
+! CHECK:           %[[VAL_0:.*]] = arith.constant -1 : index
+! CHECK:           %[[VAL_1:.*]] = arith.constant 2 : index
+! CHECK:           %[[VAL_2:.*]] = arith.constant {{.*}} : i32
+! CHECK:           %[[VAL_3:.*]] = arith.constant 6 : i32
+! CHECK:           %[[VAL_4:.*]] = arith.constant 7.000000e+00 : f32
+! CHECK:           %[[VAL_5:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_6:.*]] = arith.constant 1 : index
+! CHECK:           %[[VAL_7:.*]] = arith.constant -2.000000e+00 : f32
+! CHECK:           %[[VAL_8:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_9:.*]] = fir.load %[[ARG0]] : !fir.ref<i32>
+! CHECK:           %[[VAL_10:.*]] = fir.convert %[[VAL_9]] : (i32) -> index
+! CHECK:           %[[VAL_11:.*]] = arith.cmpi sgt, %[[VAL_10]], %[[VAL_8]] : index
+! CHECK:           %[[VAL_12:.*]] = arith.select %[[VAL_11]], %[[VAL_10]], %[[VAL_8]] : index
+! CHECK:           %[[VAL_13:.*]] = fir.alloca !fir.array<?x2xf32>, %[[VAL_12]] {bindc_name = "aa", uniq_name = "_QFss4Eaa"}
+! CHECK:           %[[VAL_14:.*]] = fir.shape %[[VAL_12]], %[[VAL_1]] : (index, index) -> !fir.shape<2>
+! CHECK:           cf.br ^bb1(%[[VAL_8]], %[[VAL_1]] : index, index)
+! CHECK:         ^bb1(%[[VAL_15:.*]]: index, %[[VAL_16:.*]]: index):
+! CHECK:           %[[VAL_17:.*]] = arith.cmpi sgt, %[[VAL_16]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_17]], ^bb2(%[[VAL_8]], %[[VAL_12]] : index, index), ^bb5
+! CHECK:         ^bb2(%[[VAL_18:.*]]: index, %[[VAL_19:.*]]: index):
+! CHECK:           %[[VAL_20:.*]] = arith.cmpi sgt, %[[VAL_19]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_20]], ^bb3, ^bb4
+! CHECK:         ^bb3:
+! CHECK:           %[[VAL_21:.*]] = arith.addi %[[VAL_18]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_22:.*]] = arith.addi %[[VAL_15]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_23:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) %[[VAL_21]], %[[VAL_22]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_7]] to %[[VAL_23]] : !fir.ref<f32>
+! CHECK:           %[[VAL_24:.*]] = arith.subi %[[VAL_19]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb2(%[[VAL_21]], %[[VAL_24]] : index, index)
+! CHECK:         ^bb4:
+! CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_15]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_26:.*]] = arith.subi %[[VAL_16]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb1(%[[VAL_25]], %[[VAL_26]] : index, index)
+! CHECK:         ^bb5:
+! CHECK:           %[[VAL_27:.*]] = arith.addi %[[VAL_10]], %[[VAL_0]] : index
+! CHECK:           %[[VAL_28:.*]] = arith.cmpi sgt, %[[VAL_27]], %[[VAL_8]] : index
+! CHECK:           %[[VAL_29:.*]] = arith.select %[[VAL_28]], %[[VAL_27]], %[[VAL_8]] : index
+! CHECK:           %[[VAL_30:.*]] = fir.slice %[[VAL_1]], %[[VAL_10]], %[[VAL_6]], %[[VAL_6]], %[[VAL_1]], %[[VAL_6]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:           %[[VAL_31:.*]] = fir.allocmem !fir.array<?x2xf32>, %[[VAL_12]]
+! CHECK:           cf.br ^bb6(%[[VAL_8]], %[[VAL_1]] : index, index)
+! CHECK:         ^bb6(%[[VAL_32:.*]]: index, %[[VAL_33:.*]]: index):
+! CHECK:           %[[VAL_34:.*]] = arith.cmpi sgt, %[[VAL_33]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_34]], ^bb7(%[[VAL_8]], %[[VAL_12]] : index, index), ^bb10
+! CHECK:         ^bb7(%[[VAL_35:.*]]: index, %[[VAL_36:.*]]: index):
+! CHECK:           %[[VAL_37:.*]] = arith.cmpi sgt, %[[VAL_36]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_37]], ^bb8, ^bb9
+! CHECK:         ^bb8:
+! CHECK:           %[[VAL_38:.*]] = arith.addi %[[VAL_35]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_39:.*]] = arith.addi %[[VAL_32]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_40:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) %[[VAL_38]], %[[VAL_39]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_41:.*]] = fir.array_coor %[[VAL_31]](%[[VAL_14]]) %[[VAL_38]], %[[VAL_39]] : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_42:.*]] = fir.load %[[VAL_40]] : !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_42]] to %[[VAL_41]] : !fir.ref<f32>
+! CHECK:           %[[VAL_43:.*]] = arith.subi %[[VAL_36]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb7(%[[VAL_38]], %[[VAL_43]] : index, index)
+! CHECK:         ^bb9:
+! CHECK:           %[[VAL_44:.*]] = arith.addi %[[VAL_32]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_45:.*]] = arith.subi %[[VAL_33]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb6(%[[VAL_44]], %[[VAL_45]] : index, index)
+! CHECK:         ^bb10:
+! CHECK:           %[[VAL_46:.*]] = arith.subi %[[VAL_9]], %[[VAL_5]] : i32
+! CHECK:           %[[VAL_47:.*]] = fir.convert %[[VAL_46]] : (i32) -> index
+! CHECK:           %[[VAL_48:.*]] = fir.slice %[[VAL_6]], %[[VAL_47]], %[[VAL_6]], %[[VAL_6]], %[[VAL_1]], %[[VAL_6]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:           cf.br ^bb11(%[[VAL_8]], %[[VAL_1]] : index, index)
+! CHECK:         ^bb11(%[[VAL_49:.*]]: index, %[[VAL_50:.*]]: index):
+! CHECK:           %[[VAL_51:.*]] = arith.cmpi sgt, %[[VAL_50]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_51]], ^bb12(%[[VAL_8]], %[[VAL_29]] : index, index), ^bb15(%[[VAL_8]], %[[VAL_1]] : index, index)
+! CHECK:         ^bb12(%[[VAL_52:.*]]: index, %[[VAL_53:.*]]: index):
+! CHECK:           %[[VAL_54:.*]] = arith.cmpi sgt, %[[VAL_53]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_54]], ^bb13, ^bb14
+! CHECK:         ^bb13:
+! CHECK:           %[[VAL_55:.*]] = arith.addi %[[VAL_52]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_56:.*]] = arith.addi %[[VAL_49]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_57:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) {{\[}}%[[VAL_48]]] %[[VAL_55]], %[[VAL_56]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_58:.*]] = fir.load %[[VAL_57]] : !fir.ref<f32>
+! CHECK:           %[[VAL_59:.*]] = arith.addf %[[VAL_58]], %[[VAL_4]] fastmath<contract> : f32
+! CHECK:           %[[VAL_60:.*]] = fir.array_coor %[[VAL_31]](%[[VAL_14]]) {{\[}}%[[VAL_30]]] %[[VAL_55]], %[[VAL_56]] : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_59]] to %[[VAL_60]] : !fir.ref<f32>
+! CHECK:           %[[VAL_61:.*]] = arith.subi %[[VAL_53]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb12(%[[VAL_55]], %[[VAL_61]] : index, index)
+! CHECK:         ^bb14:
+! CHECK:           %[[VAL_62:.*]] = arith.addi %[[VAL_49]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_63:.*]] = arith.subi %[[VAL_50]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb11(%[[VAL_62]], %[[VAL_63]] : index, index)
+! CHECK:         ^bb15(%[[VAL_64:.*]]: index, %[[VAL_65:.*]]: index):
+! CHECK:           %[[VAL_66:.*]] = arith.cmpi sgt, %[[VAL_65]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_66]], ^bb16(%[[VAL_8]], %[[VAL_12]] : index, index), ^bb19
+! CHECK:         ^bb16(%[[VAL_67:.*]]: index, %[[VAL_68:.*]]: index):
+! CHECK:           %[[VAL_69:.*]] = arith.cmpi sgt, %[[VAL_68]], %[[VAL_8]] : index
+! CHECK:           cf.cond_br %[[VAL_69]], ^bb17, ^bb18
+! CHECK:         ^bb17:
+! CHECK:           %[[VAL_70:.*]] = arith.addi %[[VAL_67]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_71:.*]] = arith.addi %[[VAL_64]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_72:.*]] = fir.array_coor %[[VAL_31]](%[[VAL_14]]) %[[VAL_70]], %[[VAL_71]] : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_73:.*]] = fir.array_coor %[[VAL_13]](%[[VAL_14]]) %[[VAL_70]], %[[VAL_71]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
+! CHECK:           %[[VAL_74:.*]] = fir.load %[[VAL_72]] : !fir.ref<f32>
+! CHECK:           fir.store %[[VAL_74]] to %[[VAL_73]] : !fir.ref<f32>
+! CHECK:           %[[VAL_75:.*]] = arith.subi %[[VAL_68]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb16(%[[VAL_70]], %[[VAL_75]] : index, index)
+! CHECK:         ^bb18:
+! CHECK:           %[[VAL_76:.*]] = arith.addi %[[VAL_64]], %[[VAL_6]] : index
+! CHECK:           %[[VAL_77:.*]] = arith.subi %[[VAL_65]], %[[VAL_6]] : index
+! CHECK:           cf.br ^bb15(%[[VAL_76]], %[[VAL_77]] : index, index)
+! CHECK:         ^bb19:
+! CHECK:           fir.freemem %[[VAL_31]] : !fir.heap<!fir.array<?x2xf32>>
+! CHECK:           %[[VAL_78:.*]] = fir.address_of(@_QQclX88e38683fcd4166fc29b4ce91ec570e4) : !fir.ref<!fir.char<1,80>>
+! CHECK:           %[[VAL_79:.*]] = fir.convert %[[VAL_78]] : (!fir.ref<!fir.char<1,80>>) -> !fir.ref<i8>
+! CHECK:           %[[VAL_80:.*]] = fir.call @_FortranAioBeginExternalListOutput(%[[VAL_3]], %[[VAL_79]], %[[VAL_2]]) fastmath<contract> {fir.llvm_memory = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = readwrite>, llvm.nocallback, llvm.nosync} : (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
+! CHECK:           %[[VAL_81:.*]] = fir.slice %[[VAL_6]], %[[VAL_1]], %[[VAL_6]], %[[VAL_6]], %[[VAL_1]], %[[VAL_6]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:           %[[VAL_82:.*]] = fir.embox %[[VAL_13]](%[[VAL_14]]) {{\[}}%[[VAL_81]]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<2x?xf32>>
+! CHECK:           %[[VAL_83:.*]] = fir.convert %[[VAL_82]] : (!fir.box<!fir.array<2x?xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_84:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_80]], %[[VAL_83]]) fastmath<contract> {llvm.nocallback, llvm.nosync} : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:           %[[VAL_85:.*]] = fir.slice %[[VAL_47]], %[[VAL_10]], %[[VAL_6]], %[[VAL_6]], %[[VAL_1]], %[[VAL_6]] : (index, index, index, index, index, index) -> !fir.slice<2>
+! CHECK:           %[[VAL_86:.*]] = fir.embox %[[VAL_13]](%[[VAL_14]]) {{\[}}%[[VAL_85]]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
+! CHECK:           %[[VAL_87:.*]] = fir.convert %[[VAL_86]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
+! CHECK:           %[[VAL_88:.*]] = fir.call @_FortranAioOutputDescriptor(%[[VAL_80]], %[[VAL_87]]) fastmath<contract> {llvm.nocallback, llvm.nosync} : (!fir.ref<i8>, !fir.box<none>) -> i1
+! CHECK:           %[[VAL_89:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_80]]) fastmath<contract> {fir.llvm_memory = #llvm.memory_effects<other = none, argMem = readwrite, inaccessibleMem = readwrite>, llvm.nocallback, llvm.nosync} : (!fir.ref<i8>) -> i32
+! CHECK:           return
+! CHECK:         }
+
 subroutine ss2(N)
   real aa(N)
   aa = -2
@@ -41,351 +375,6 @@ subroutine ss4(N)
   print*, aa(1:2,:), aa(N-1:N,:)
 end
 
-! CHECK-LABEL: func @_QPss2(
-! CHECK-SAME:               %arg0: !fir.ref<i32> {fir.bindc_name = "n"}) {
-! CHECK-DAG: %[[C_m1:[-0-9a-z_]+]] = arith.constant -1 : index
-! CHECK-DAG: %[[C_2:[-0-9a-z_]+]] = arith.constant 2 : index
-! CHECK-DAG: %[[C_1:[-0-9a-z_]+]] = arith.constant 1 : index
-! CHECK-DAG: %[[C_27_i32:[-0-9a-z_]+]] = arith.constant 27 : i32
-! CHECK-DAG: %[[C_6_i32:[-0-9a-z_]+]] = arith.constant 6 : i32
-! CHECK-DAG: %[[C_st:[-0-9a-z_]+]] = arith.constant 7.000000e+00 : f32
-! CHECK-DAG: %[[C_1_i32:[-0-9a-z_]+]] = arith.constant 1 : i32
-! CHECK-DAG: %[[C_st_0:[-0-9a-z_]+]] = arith.constant -2.000000e+00 : f32
-! CHECK-DAG: %[[C_0:[-0-9a-z_]+]] = arith.constant 0 : index
-! CHECK:   %[[V_0:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-! CHECK:   %[[V_1:[0-9]+]] = fir.convert %[[V_0:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_2:[0-9]+]] = arith.cmpi sgt, %[[V_1]], %[[C_0]] : index
-! CHECK:   %[[V_3:[0-9]+]] = arith.select %[[V_2]], %[[V_1]], %[[C_0]] : index
-! CHECK:   %[[V_4:[0-9]+]] = fir.alloca !fir.array<?xf32>, %[[V_3]] {bindc_name = "aa", uniq_name = "_QFss2Eaa"}
-! CHECK:   %[[V_5:[0-9]+]] = fir.shape %[[V_3:[0-9]+]] : (index) -> !fir.shape<1>
-! CHECK:   cf.br ^bb1(%[[C_0]], %[[V_3:[0-9]+]] : index, index)
-! CHECK: ^bb1(%[[V_6:[0-9]+]]: index, %[[V_7:[0-9]+]]: index):  // 2 preds: ^bb0, ^bb2
-! CHECK:   %[[V_8:[0-9]+]] = arith.cmpi sgt, %[[V_7]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_8]], ^bb2, ^bb3
-! CHECK: ^bb2:  // pred: ^bb1
-! CHECK:   %[[V_9:[0-9]+]] = arith.addi %[[V_6]], %[[C_1]] : index
-! CHECK:   %[[V_10:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) %[[V_9:[0-9]+]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:   fir.store %[[C_st_0]] to %[[V_10:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_11:[0-9]+]] = arith.subi %[[V_7]], %[[C_1]] : index
-! CHECK:   cf.br ^bb1(%[[V_9]], %[[V_11:[0-9]+]] : index, index)
-! CHECK: ^bb3:  // pred: ^bb1
-! CHECK:   %[[V_12:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-! CHECK:   %[[V_13:[0-9]+]] = fir.convert %[[V_12:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_14:[0-9]+]] = arith.addi %[[V_13]], %[[C_m1]] : index
-! CHECK:   %[[V_15:[0-9]+]] = arith.cmpi sgt, %[[V_14]], %[[C_0]] : index
-! CHECK:   %[[V_16:[0-9]+]] = arith.select %[[V_15]], %[[V_14]], %[[C_0]] : index
-! CHECK:   %[[V_17:[0-9]+]] = fir.slice %[[C_2]], %[[V_13]], %[[C_1]] : (index, index, index) -> !fir.slice<1>
-! CHECK:   %[[V_18:[0-9]+]] = fir.allocmem !fir.array<?xf32>, %[[V_3]]
-! CHECK:   cf.br ^bb4(%[[C_0]], %[[V_3:[0-9]+]] : index, index)
-! CHECK: ^bb4(%[[V_19:[0-9]+]]: index, %[[V_20:[0-9]+]]: index):  // 2 preds: ^bb3, ^bb5
-! CHECK:   %[[V_21:[0-9]+]] = arith.cmpi sgt, %[[V_20]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_21]], ^bb5, ^bb6
-! CHECK: ^bb5:  // pred: ^bb4
-! CHECK:   %[[V_22:[0-9]+]] = arith.addi %[[V_19]], %[[C_1]] : index
-! CHECK:   %[[V_23:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) %[[V_22:[0-9]+]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:   %[[V_24:[0-9]+]] = fir.array_coor %[[V_18]](%[[V_5]]) %[[V_22:[0-9]+]] : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:   %[[V_25:[0-9]+]] = fir.load %[[V_23:[0-9]+]] : !fir.ref<f32>
-! CHECK:   fir.store %[[V_25]] to %[[V_24:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_26:[0-9]+]] = arith.subi %[[V_20]], %[[C_1]] : index
-! CHECK:   cf.br ^bb4(%[[V_22]], %[[V_26:[0-9]+]] : index, index)
-! CHECK: ^bb6:  // pred: ^bb4
-! CHECK:   %[[V_27:[0-9]+]] = arith.subi %[[V_12]], %[[C_1_i32]] : i32
-! CHECK:   %[[V_28:[0-9]+]] = fir.convert %[[V_27:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_29:[0-9]+]] = fir.slice %[[C_1]], %[[V_28]], %[[C_1]] : (index, index, index) -> !fir.slice<1>
-! CHECK:   cf.br ^bb7(%[[C_0]], %[[V_16:[0-9]+]] : index, index)
-! CHECK: ^bb7(%[[V_30:[0-9]+]]: index, %[[V_31:[0-9]+]]: index):  // 2 preds: ^bb6, ^bb8
-! CHECK:   %[[V_32:[0-9]+]] = arith.cmpi sgt, %[[V_31]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_32]], ^bb8, ^bb9(%[[C_0]], %[[V_3:[0-9]+]] : index, index)
-! CHECK: ^bb8:  // pred: ^bb7
-! CHECK:   %[[V_33:[0-9]+]] = arith.addi %[[V_30]], %[[C_1]] : index
-! CHECK:   %[[V_34:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) [%[[V_29]]] %[[V_33:[0-9]+]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
-! CHECK:   %[[V_35:[0-9]+]] = fir.load %[[V_34:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_36:[0-9]+]] = arith.addf %[[V_35]], %[[C_st]] fastmath<contract> : f32
-! CHECK:   %[[V_37:[0-9]+]] = fir.array_coor %[[V_18]](%[[V_5]]) [%[[V_17]]] %[[V_33:[0-9]+]] : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>, index) -> !fir.ref<f32>
-! CHECK:   fir.store %[[V_36]] to %[[V_37:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_38:[0-9]+]] = arith.subi %[[V_31]], %[[C_1]] : index
-! CHECK:   cf.br ^bb7(%[[V_33]], %[[V_38:[0-9]+]] : index, index)
-! CHECK: ^bb9(%[[V_39:[0-9]+]]: index, %[[V_40:[0-9]+]]: index):  // 2 preds: ^bb7, ^bb10
-! CHECK:   %[[V_41:[0-9]+]] = arith.cmpi sgt, %[[V_40]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_41]], ^bb10, ^bb11
-! CHECK: ^bb10:  // pred: ^bb9
-! CHECK:   %[[V_42:[0-9]+]] = arith.addi %[[V_39]], %[[C_1]] : index
-! CHECK:   %[[V_43:[0-9]+]] = fir.array_coor %[[V_18]](%[[V_5]]) %[[V_42:[0-9]+]] : (!fir.heap<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:   %[[V_44:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) %[[V_42:[0-9]+]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, index) -> !fir.ref<f32>
-! CHECK:   %[[V_45:[0-9]+]] = fir.load %[[V_43:[0-9]+]] : !fir.ref<f32>
-! CHECK:   fir.store %[[V_45]] to %[[V_44:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_46:[0-9]+]] = arith.subi %[[V_40]], %[[C_1]] : index
-! CHECK:   cf.br ^bb9(%[[V_42]], %[[V_46:[0-9]+]] : index, index)
-! CHECK: ^bb11:  // pred: ^bb9
-! CHECK:   fir.freemem %[[V_18:[0-9]+]] : !fir.heap<!fir.array<?xf32>>
-! CHECK:   %[[V_49:[0-9]+]] = fir.call @_FortranAioBeginExternalListOutput(%[[C_6_i32]], %{{.*}}, %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:   %[[V_50:[0-9]+]] = fir.slice %[[C_1]], %[[C_2]], %[[C_1]] : (index, index, index) -> !fir.slice<1>
-! CHECK:   %[[V_51:[0-9]+]] = fir.embox %[[V_4]](%[[V_5]]) [%[[V_50]]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<2xf32>>
-! CHECK:   %[[V_52:[0-9]+]] = fir.convert %[[V_51:[0-9]+]] : (!fir.box<!fir.array<2xf32>>) -> !fir.box<none>
-! CHECK:   %[[V_53:[0-9]+]] = fir.call @_FortranAioOutputDescriptor(%[[V_49]], %[[V_52]]) fastmath<contract> {{.*}}: (!fir.ref<i8>, !fir.box<none>) -> i1
-! CHECK:   %[[V_54:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-! CHECK:   %[[V_55:[0-9]+]] = arith.subi %[[V_54]], %[[C_1_i32]] : i32
-! CHECK:   %[[V_56:[0-9]+]] = fir.convert %[[V_55:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_57:[0-9]+]] = fir.convert %[[V_54:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_58:[0-9]+]] = fir.slice %[[V_56]], %[[V_57]], %[[C_1]] : (index, index, index) -> !fir.slice<1>
-! CHECK:   %[[V_59:[0-9]+]] = fir.embox %[[V_4]](%[[V_5]]) [%[[V_58]]] : (!fir.ref<!fir.array<?xf32>>, !fir.shape<1>, !fir.slice<1>) -> !fir.box<!fir.array<?xf32>>
-! CHECK:   %[[V_60:[0-9]+]] = fir.convert %[[V_59:[0-9]+]] : (!fir.box<!fir.array<?xf32>>) -> !fir.box<none>
-! CHECK:   %[[V_61:[0-9]+]] = fir.call @_FortranAioOutputDescriptor(%[[V_49]], %[[V_60]]) fastmath<contract> {{.*}}: (!fir.ref<i8>, !fir.box<none>) -> i1
-! CHECK:   %[[V_62:[0-9]+]] = fir.call @_FortranAioEndIoStatement(%[[V_49]]) fastmath<contract> {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:   return
-! CHECK:   }
-
-! CHECK-LABEL: func @_QPss3(
-! CHECK-SAME:               %arg0: !fir.ref<i32> {fir.bindc_name = "n"}) {
-! CHECK-DAG: %[[C_m1:[-0-9a-z_]+]] = arith.constant -1 : index
-! CHECK-DAG: %[[C_2:[-0-9a-z_]+]] = arith.constant 2 : index
-! CHECK-DAG: %[[C_1:[-0-9a-z_]+]] = arith.constant 1 : index
-! CHECK-DAG: %[[C_34_i32:[-0-9a-z_]+]] = arith.constant 34 : i32
-! CHECK-DAG: %[[C_6_i32:[-0-9a-z_]+]] = arith.constant 6 : i32
-! CHECK-DAG: %[[C_st:[-0-9a-z_]+]] = arith.constant 7.000000e+00 : f32
-! CHECK-DAG: %[[C_1_i32:[-0-9a-z_]+]] = arith.constant 1 : i32
-! CHECK-DAG: %[[C_st_0:[-0-9a-z_]+]] = arith.constant -2.000000e+00 : f32
-! CHECK-DAG: %[[C_0:[-0-9a-z_]+]] = arith.constant 0 : index
-! CHECK:   %[[V_0:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-! CHECK:   %[[V_1:[0-9]+]] = fir.convert %[[V_0:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_2:[0-9]+]] = arith.cmpi sgt, %[[V_1]], %[[C_0]] : index
-! CHECK:   %[[V_3:[0-9]+]] = arith.select %[[V_2]], %[[V_1]], %[[C_0]] : index
-! CHECK:   %[[V_4:[0-9]+]] = fir.alloca !fir.array<2x?xf32>, %[[V_3]] {bindc_name = "aa", uniq_name = "_QFss3Eaa"}
-! CHECK:   %[[V_5:[0-9]+]] = fir.shape %[[C_2]], %[[V_3:[0-9]+]] : (index, index) -> !fir.shape<2>
-! CHECK:   cf.br ^bb1(%[[C_0]], %[[V_3:[0-9]+]] : index, index)
-! CHECK: ^bb1(%[[V_6:[0-9]+]]: index, %[[V_7:[0-9]+]]: index):  // 2 preds: ^bb0, ^bb4
-! CHECK:   %[[V_8:[0-9]+]] = arith.cmpi sgt, %[[V_7]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_8]], ^bb2(%[[C_0]], %[[C_2]] : index, index), ^bb5
-! CHECK: ^bb2(%[[V_9:[0-9]+]]: index, %[[V_10:[0-9]+]]: index):  // 2 preds: ^bb1, ^bb3
-! CHECK:   %[[V_11:[0-9]+]] = arith.cmpi sgt, %[[V_10]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_11]], ^bb3, ^bb4
-! CHECK: ^bb3:  // pred: ^bb2
-! CHECK:   %[[V_12:[0-9]+]] = arith.addi %[[V_9]], %[[C_1]] : index
-! CHECK:   %[[V_13:[0-9]+]] = arith.addi %[[V_6]], %[[C_1]] : index
-! CHECK:   %[[V_14:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) %[[V_12]], %[[V_13:[0-9]+]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-! CHECK:   fir.store %[[C_st_0]] to %[[V_14:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_15:[0-9]+]] = arith.subi %[[V_10]], %[[C_1]] : index
-! CHECK:   cf.br ^bb2(%[[V_12]], %[[V_15:[0-9]+]] : index, index)
-! CHECK: ^bb4:  // pred: ^bb2
-! CHECK:   %[[V_16:[0-9]+]] = arith.addi %[[V_6]], %[[C_1]] : index
-! CHECK:   %[[V_17:[0-9]+]] = arith.subi %[[V_7]], %[[C_1]] : index
-! CHECK:   cf.br ^bb1(%[[V_16]], %[[V_17:[0-9]+]] : index, index)
-! CHECK: ^bb5:  // pred: ^bb1
-! CHECK:   %[[V_18:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-! CHECK:   %[[V_19:[0-9]+]] = fir.convert %[[V_18:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_20:[0-9]+]] = arith.addi %[[V_19]], %[[C_m1]] : index
-! CHECK:   %[[V_21:[0-9]+]] = arith.cmpi sgt, %[[V_20]], %[[C_0]] : index
-! CHECK:   %[[V_22:[0-9]+]] = arith.select %[[V_21]], %[[V_20]], %[[C_0]] : index
-! CHECK:   %[[V_23:[0-9]+]] = fir.slice %[[C_1]], %[[C_2]], %[[C_1]], %[[C_2]], %[[V_19]], %[[C_1]] : (index, index, index, index, index, index) -> !fir.slice<2>
-! CHECK:   %[[V_24:[0-9]+]] = fir.allocmem !fir.array<2x?xf32>, %[[V_3]]
-! CHECK:   cf.br ^bb6(%[[C_0]], %[[V_3:[0-9]+]] : index, index)
-! CHECK: ^bb6(%[[V_25:[0-9]+]]: index, %[[V_26:[0-9]+]]: index):  // 2 preds: ^bb5, ^bb9
-! CHECK:   %[[V_27:[0-9]+]] = arith.cmpi sgt, %[[V_26]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_27]], ^bb7(%[[C_0]], %[[C_2]] : index, index), ^bb10
-! CHECK: ^bb7(%[[V_28:[0-9]+]]: index, %[[V_29:[0-9]+]]: index):  // 2 preds: ^bb6, ^bb8
-! CHECK:   %[[V_30:[0-9]+]] = arith.cmpi sgt, %[[V_29]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_30]], ^bb8, ^bb9
-! CHECK: ^bb8:  // pred: ^bb7
-! CHECK:   %[[V_31:[0-9]+]] = arith.addi %[[V_28]], %[[C_1]] : index
-! CHECK:   %[[V_32:[0-9]+]] = arith.addi %[[V_25]], %[[C_1]] : index
-! CHECK:   %[[V_33:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) %[[V_31]], %[[V_32:[0-9]+]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-! CHECK:   %[[V_34:[0-9]+]] = fir.array_coor %[[V_24]](%[[V_5]]) %[[V_31]], %[[V_32:[0-9]+]] : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-! CHECK:   %[[V_35:[0-9]+]] = fir.load %[[V_33:[0-9]+]] : !fir.ref<f32>
-! CHECK:   fir.store %[[V_35]] to %[[V_34:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_36:[0-9]+]] = arith.subi %[[V_29]], %[[C_1]] : index
-! CHECK:   cf.br ^bb7(%[[V_31]], %[[V_36:[0-9]+]] : index, index)
-! CHECK: ^bb9:  // pred: ^bb7
-! CHECK:   %[[V_37:[0-9]+]] = arith.addi %[[V_25]], %[[C_1]] : index
-! CHECK:   %[[V_38:[0-9]+]] = arith.subi %[[V_26]], %[[C_1]] : index
-! CHECK:   cf.br ^bb6(%[[V_37]], %[[V_38:[0-9]+]] : index, index)
-! CHECK: ^bb10:  // pred: ^bb6
-! CHECK:   %[[V_39:[0-9]+]] = arith.subi %[[V_18]], %[[C_1_i32]] : i32
-! CHECK:   %[[V_40:[0-9]+]] = fir.convert %[[V_39:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_41:[0-9]+]] = fir.slice %[[C_1]], %[[C_2]], %[[C_1]], %[[C_1]], %[[V_40]], %[[C_1]] : (index, index, index, index, index, index) -> !fir.slice<2>
-! CHECK:   cf.br ^bb11(%[[C_0]], %[[V_22:[0-9]+]] : index, index)
-! CHECK: ^bb11(%[[V_42:[0-9]+]]: index, %[[V_43:[0-9]+]]: index):  // 2 preds: ^bb10, ^bb14
-! CHECK:   %[[V_44:[0-9]+]] = arith.cmpi sgt, %[[V_43]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_44]], ^bb12(%[[C_0]], %[[C_2]] : index, index), ^bb15(%[[C_0]], %[[V_3:[0-9]+]] : index, index)
-! CHECK: ^bb12(%[[V_45:[0-9]+]]: index, %[[V_46:[0-9]+]]: index):  // 2 preds: ^bb11, ^bb13
-! CHECK:   %[[V_47:[0-9]+]] = arith.cmpi sgt, %[[V_46]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_47]], ^bb13, ^bb14
-! CHECK: ^bb13:  // pred: ^bb12
-! CHECK:   %[[V_48:[0-9]+]] = arith.addi %[[V_45]], %[[C_1]] : index
-! CHECK:   %[[V_49:[0-9]+]] = arith.addi %[[V_42]], %[[C_1]] : index
-! CHECK:   %[[V_50:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) [%[[V_41]]] %[[V_48]], %[[V_49:[0-9]+]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
-! CHECK:   %[[V_51:[0-9]+]] = fir.load %[[V_50:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_52:[0-9]+]] = arith.addf %[[V_51]], %[[C_st]] fastmath<contract> : f32
-! CHECK:   %[[V_53:[0-9]+]] = fir.array_coor %[[V_24]](%[[V_5]]) [%[[V_23]]] %[[V_48]], %[[V_49:[0-9]+]] : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
-! CHECK:   fir.store %[[V_52]] to %[[V_53:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_54:[0-9]+]] = arith.subi %[[V_46]], %[[C_1]] : index
-! CHECK:   cf.br ^bb12(%[[V_48]], %[[V_54:[0-9]+]] : index, index)
-! CHECK: ^bb14:  // pred: ^bb12
-! CHECK:   %[[V_55:[0-9]+]] = arith.addi %[[V_42]], %[[C_1]] : index
-! CHECK:   %[[V_56:[0-9]+]] = arith.subi %[[V_43]], %[[C_1]] : index
-! CHECK:   cf.br ^bb11(%[[V_55]], %[[V_56:[0-9]+]] : index, index)
-! CHECK: ^bb15(%[[V_57:[0-9]+]]: index, %[[V_58:[0-9]+]]: index):  // 2 preds: ^bb11, ^bb18
-! CHECK:   %[[V_59:[0-9]+]] = arith.cmpi sgt, %[[V_58]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_59]], ^bb16(%[[C_0]], %[[C_2]] : index, index), ^bb19
-! CHECK: ^bb16(%[[V_60:[0-9]+]]: index, %[[V_61:[0-9]+]]: index):  // 2 preds: ^bb15, ^bb17
-! CHECK:   %[[V_62:[0-9]+]] = arith.cmpi sgt, %[[V_61]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_62]], ^bb17, ^bb18
-! CHECK: ^bb17:  // pred: ^bb16
-! CHECK:   %[[V_63:[0-9]+]] = arith.addi %[[V_60]], %[[C_1]] : index
-! CHECK:   %[[V_64:[0-9]+]] = arith.addi %[[V_57]], %[[C_1]] : index
-! CHECK:   %[[V_65:[0-9]+]] = fir.array_coor %[[V_24]](%[[V_5]]) %[[V_63]], %[[V_64:[0-9]+]] : (!fir.heap<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-! CHECK:   %[[V_66:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) %[[V_63]], %[[V_64:[0-9]+]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-! CHECK:   %[[V_67:[0-9]+]] = fir.load %[[V_65:[0-9]+]] : !fir.ref<f32>
-! CHECK:   fir.store %[[V_67]] to %[[V_66:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_68:[0-9]+]] = arith.subi %[[V_61]], %[[C_1]] : index
-! CHECK:   cf.br ^bb16(%[[V_63]], %[[V_68:[0-9]+]] : index, index)
-! CHECK: ^bb18:  // pred: ^bb16
-! CHECK:   %[[V_69:[0-9]+]] = arith.addi %[[V_57]], %[[C_1]] : index
-! CHECK:   %[[V_70:[0-9]+]] = arith.subi %[[V_58]], %[[C_1]] : index
-! CHECK:   cf.br ^bb15(%[[V_69]], %[[V_70:[0-9]+]] : index, index)
-! CHECK: ^bb19:  // pred: ^bb15
-! CHECK:   fir.freemem %[[V_24:[0-9]+]] : !fir.heap<!fir.array<2x?xf32>>
-! CHECK:   %[[V_73:[0-9]+]] = fir.call @_FortranAioBeginExternalListOutput(%[[C_6_i32]], %{{.*}}, %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:   %[[V_74:[0-9]+]] = fir.slice %[[C_1]], %[[C_2]], %[[C_1]], %[[C_1]], %[[C_2]], %[[C_1]] : (index, index, index, index, index, index) -> !fir.slice<2>
-! CHECK:   %[[V_75:[0-9]+]] = fir.embox %[[V_4]](%[[V_5]]) [%[[V_74]]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x2xf32>>
-! CHECK:   %[[V_76:[0-9]+]] = fir.convert %[[V_75:[0-9]+]] : (!fir.box<!fir.array<?x2xf32>>) -> !fir.box<none>
-! CHECK:   %[[V_77:[0-9]+]] = fir.call @_FortranAioOutputDescriptor(%[[V_73]], %[[V_76]]) fastmath<contract> {{.*}}: (!fir.ref<i8>, !fir.box<none>) -> i1
-! CHECK:   %[[V_78:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-! CHECK:   %[[V_79:[0-9]+]] = arith.subi %[[V_78]], %[[C_1_i32]] : i32
-! CHECK:   %[[V_80:[0-9]+]] = fir.convert %[[V_79:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_81:[0-9]+]] = fir.convert %[[V_78:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_82:[0-9]+]] = fir.slice %[[C_1]], %[[C_2]], %[[C_1]], %[[V_80]], %[[V_81]], %[[C_1]] : (index, index, index, index, index, index) -> !fir.slice<2>
-! CHECK:   %[[V_83:[0-9]+]] = fir.embox %[[V_4]](%[[V_5]]) [%[[V_82]]] : (!fir.ref<!fir.array<2x?xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
-! CHECK:   %[[V_84:[0-9]+]] = fir.convert %[[V_83:[0-9]+]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
-! CHECK:   %[[V_85:[0-9]+]] = fir.call @_FortranAioOutputDescriptor(%[[V_73]], %[[V_84]]) fastmath<contract> {{.*}}: (!fir.ref<i8>, !fir.box<none>) -> i1
-! CHECK:   %[[V_86:[0-9]+]] = fir.call @_FortranAioEndIoStatement(%[[V_73]]) fastmath<contract> {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:   return
-! CHECK:   }
-
-! CHECK-LABEL: func @_QPss4(
-! CHECK-SAME:               %arg0: !fir.ref<i32> {fir.bindc_name = "n"}) {
-! CHECK-DAG: %[[C_2:[-0-9a-z_]+]] = arith.constant 2 : index
-! CHECK-DAG: %[[C_m1:[-0-9a-z_]+]] = arith.constant -1 : index
-! CHECK-DAG: %[[C_1:[-0-9a-z_]+]] = arith.constant 1 : index
-! CHECK-DAG: %[[C_41_i32:[-0-9a-z_]+]] = arith.constant 41 : i32
-! CHECK-DAG: %[[C_6_i32:[-0-9a-z_]+]] = arith.constant 6 : i32
-! CHECK-DAG: %[[C_st:[-0-9a-z_]+]] = arith.constant 7.000000e+00 : f32
-! CHECK-DAG: %[[C_1_i32:[-0-9a-z_]+]] = arith.constant 1 : i32
-! CHECK-DAG: %[[C_st_0:[-0-9a-z_]+]] = arith.constant -2.000000e+00 : f32
-! CHECK-DAG: %[[C_0:[-0-9a-z_]+]] = arith.constant 0 : index
-! CHECK:   %[[V_0:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-! CHECK:   %[[V_1:[0-9]+]] = fir.convert %[[V_0:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_2:[0-9]+]] = arith.cmpi sgt, %[[V_1]], %[[C_0]] : index
-! CHECK:   %[[V_3:[0-9]+]] = arith.select %[[V_2]], %[[V_1]], %[[C_0]] : index
-! CHECK:   %[[V_4:[0-9]+]] = fir.alloca !fir.array<?x2xf32>, %[[V_3]] {bindc_name = "aa", uniq_name = "_QFss4Eaa"}
-! CHECK:   %[[V_5:[0-9]+]] = fir.shape %[[V_3]], %[[C_2]] : (index, index) -> !fir.shape<2>
-! CHECK:   cf.br ^bb1(%[[C_0]], %[[C_2]] : index, index)
-! CHECK: ^bb1(%[[V_6:[0-9]+]]: index, %[[V_7:[0-9]+]]: index):  // 2 preds: ^bb0, ^bb4
-! CHECK:   %[[V_8:[0-9]+]] = arith.cmpi sgt, %[[V_7]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_8]], ^bb2(%[[C_0]], %[[V_3:[0-9]+]] : index, index), ^bb5
-! CHECK: ^bb2(%[[V_9:[0-9]+]]: index, %[[V_10:[0-9]+]]: index):  // 2 preds: ^bb1, ^bb3
-! CHECK:   %[[V_11:[0-9]+]] = arith.cmpi sgt, %[[V_10]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_11]], ^bb3, ^bb4
-! CHECK: ^bb3:  // pred: ^bb2
-! CHECK:   %[[V_12:[0-9]+]] = arith.addi %[[V_9]], %[[C_1]] : index
-! CHECK:   %[[V_13:[0-9]+]] = arith.addi %[[V_6]], %[[C_1]] : index
-! CHECK:   %[[V_14:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) %[[V_12]], %[[V_13:[0-9]+]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-! CHECK:   fir.store %[[C_st_0]] to %[[V_14:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_15:[0-9]+]] = arith.subi %[[V_10]], %[[C_1]] : index
-! CHECK:   cf.br ^bb2(%[[V_12]], %[[V_15:[0-9]+]] : index, index)
-! CHECK: ^bb4:  // pred: ^bb2
-! CHECK:   %[[V_16:[0-9]+]] = arith.addi %[[V_6]], %[[C_1]] : index
-! CHECK:   %[[V_17:[0-9]+]] = arith.subi %[[V_7]], %[[C_1]] : index
-! CHECK:   cf.br ^bb1(%[[V_16]], %[[V_17:[0-9]+]] : index, index)
-! CHECK: ^bb5:  // pred: ^bb1
-! CHECK:   %[[V_18:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-! CHECK:   %[[V_19:[0-9]+]] = fir.convert %[[V_18:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_20:[0-9]+]] = arith.addi %[[V_19]], %[[C_m1]] : index
-! CHECK:   %[[V_21:[0-9]+]] = arith.cmpi sgt, %[[V_20]], %[[C_0]] : index
-! CHECK:   %[[V_22:[0-9]+]] = arith.select %[[V_21]], %[[V_20]], %[[C_0]] : index
-! CHECK:   %[[V_23:[0-9]+]] = fir.slice %[[C_2]], %[[V_19]], %[[C_1]], %[[C_1]], %[[C_2]], %[[C_1]] : (index, index, index, index, index, index) -> !fir.slice<2>
-! CHECK:   %[[V_24:[0-9]+]] = fir.allocmem !fir.array<?x2xf32>, %[[V_3]]
-! CHECK:   cf.br ^bb6(%[[C_0]], %[[C_2]] : index, index)
-! CHECK: ^bb6(%[[V_25:[0-9]+]]: index, %[[V_26:[0-9]+]]: index):  // 2 preds: ^bb5, ^bb9
-! CHECK:   %[[V_27:[0-9]+]] = arith.cmpi sgt, %[[V_26]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_27]], ^bb7(%[[C_0]], %[[V_3:[0-9]+]] : index, index), ^bb10
-! CHECK: ^bb7(%[[V_28:[0-9]+]]: index, %[[V_29:[0-9]+]]: index):  // 2 preds: ^bb6, ^bb8
-! CHECK:   %[[V_30:[0-9]+]] = arith.cmpi sgt, %[[V_29]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_30]], ^bb8, ^bb9
-! CHECK: ^bb8:  // pred: ^bb7
-! CHECK:   %[[V_31:[0-9]+]] = arith.addi %[[V_28]], %[[C_1]] : index
-! CHECK:   %[[V_32:[0-9]+]] = arith.addi %[[V_25]], %[[C_1]] : index
-! CHECK:   %[[V_33:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) %[[V_31]], %[[V_32:[0-9]+]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-! CHECK:   %[[V_34:[0-9]+]] = fir.array_coor %[[V_24]](%[[V_5]]) %[[V_31]], %[[V_32:[0-9]+]] : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-! CHECK:   %[[V_35:[0-9]+]] = fir.load %[[V_33:[0-9]+]] : !fir.ref<f32>
-! CHECK:   fir.store %[[V_35]] to %[[V_34:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_36:[0-9]+]] = arith.subi %[[V_29]], %[[C_1]] : index
-! CHECK:   cf.br ^bb7(%[[V_31]], %[[V_36:[0-9]+]] : index, index)
-! CHECK: ^bb9:  // pred: ^bb7
-! CHECK:   %[[V_37:[0-9]+]] = arith.addi %[[V_25]], %[[C_1]] : index
-! CHECK:   %[[V_38:[0-9]+]] = arith.subi %[[V_26]], %[[C_1]] : index
-! CHECK:   cf.br ^bb6(%[[V_37]], %[[V_38:[0-9]+]] : index, index)
-! CHECK: ^bb10:  // pred: ^bb6
-! CHECK:   %[[V_39:[0-9]+]] = arith.subi %[[V_18]], %[[C_1_i32]] : i32
-! CHECK:   %[[V_40:[0-9]+]] = fir.convert %[[V_39:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_41:[0-9]+]] = fir.slice %[[C_1]], %[[V_40]], %[[C_1]], %[[C_1]], %[[C_2]], %[[C_1]] : (index, index, index, index, index, index) -> !fir.slice<2>
-! CHECK:   cf.br ^bb11(%[[C_0]], %[[C_2]] : index, index)
-! CHECK: ^bb11(%[[V_42:[0-9]+]]: index, %[[V_43:[0-9]+]]: index):  // 2 preds: ^bb10, ^bb14
-! CHECK:   %[[V_44:[0-9]+]] = arith.cmpi sgt, %[[V_43]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_44]], ^bb12(%[[C_0]], %[[V_22:[0-9]+]] : index, index), ^bb15(%[[C_0]], %[[C_2]] : index, index)
-! CHECK: ^bb12(%[[V_45:[0-9]+]]: index, %[[V_46:[0-9]+]]: index):  // 2 preds: ^bb11, ^bb13
-! CHECK:   %[[V_47:[0-9]+]] = arith.cmpi sgt, %[[V_46]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_47]], ^bb13, ^bb14
-! CHECK: ^bb13:  // pred: ^bb12
-! CHECK:   %[[V_48:[0-9]+]] = arith.addi %[[V_45]], %[[C_1]] : index
-! CHECK:   %[[V_49:[0-9]+]] = arith.addi %[[V_42]], %[[C_1]] : index
-! CHECK:   %[[V_50:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) [%[[V_41]]] %[[V_48]], %[[V_49:[0-9]+]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
-! CHECK:   %[[V_51:[0-9]+]] = fir.load %[[V_50:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_52:[0-9]+]] = arith.addf %[[V_51]], %[[C_st]] fastmath<contract> : f32
-! CHECK:   %[[V_53:[0-9]+]] = fir.array_coor %[[V_24]](%[[V_5]]) [%[[V_23]]] %[[V_48]], %[[V_49:[0-9]+]] : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>, index, index) -> !fir.ref<f32>
-! CHECK:   fir.store %[[V_52]] to %[[V_53:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_54:[0-9]+]] = arith.subi %[[V_46]], %[[C_1]] : index
-! CHECK:   cf.br ^bb12(%[[V_48]], %[[V_54:[0-9]+]] : index, index)
-! CHECK: ^bb14:  // pred: ^bb12
-! CHECK:   %[[V_55:[0-9]+]] = arith.addi %[[V_42]], %[[C_1]] : index
-! CHECK:   %[[V_56:[0-9]+]] = arith.subi %[[V_43]], %[[C_1]] : index
-! CHECK:   cf.br ^bb11(%[[V_55]], %[[V_56:[0-9]+]] : index, index)
-! CHECK: ^bb15(%[[V_57:[0-9]+]]: index, %[[V_58:[0-9]+]]: index):  // 2 preds: ^bb11, ^bb18
-! CHECK:   %[[V_59:[0-9]+]] = arith.cmpi sgt, %[[V_58]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_59]], ^bb16(%[[C_0]], %[[V_3:[0-9]+]] : index, index), ^bb19
-! CHECK: ^bb16(%[[V_60:[0-9]+]]: index, %[[V_61:[0-9]+]]: index):  // 2 preds: ^bb15, ^bb17
-! CHECK:   %[[V_62:[0-9]+]] = arith.cmpi sgt, %[[V_61]], %[[C_0]] : index
-! CHECK:   cf.cond_br %[[V_62]], ^bb17, ^bb18
-! CHECK: ^bb17:  // pred: ^bb16
-! CHECK:   %[[V_63:[0-9]+]] = arith.addi %[[V_60]], %[[C_1]] : index
-! CHECK:   %[[V_64:[0-9]+]] = arith.addi %[[V_57]], %[[C_1]] : index
-! CHECK:   %[[V_65:[0-9]+]] = fir.array_coor %[[V_24]](%[[V_5]]) %[[V_63]], %[[V_64:[0-9]+]] : (!fir.heap<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-! CHECK:   %[[V_66:[0-9]+]] = fir.array_coor %[[V_4]](%[[V_5]]) %[[V_63]], %[[V_64:[0-9]+]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, index, index) -> !fir.ref<f32>
-! CHECK:   %[[V_67:[0-9]+]] = fir.load %[[V_65:[0-9]+]] : !fir.ref<f32>
-! CHECK:   fir.store %[[V_67]] to %[[V_66:[0-9]+]] : !fir.ref<f32>
-! CHECK:   %[[V_68:[0-9]+]] = arith.subi %[[V_61]], %[[C_1]] : index
-! CHECK:   cf.br ^bb16(%[[V_63]], %[[V_68:[0-9]+]] : index, index)
-! CHECK: ^bb18:  // pred: ^bb16
-! CHECK:   %[[V_69:[0-9]+]] = arith.addi %[[V_57]], %[[C_1]] : index
-! CHECK:   %[[V_70:[0-9]+]] = arith.subi %[[V_58]], %[[C_1]] : index
-! CHECK:   cf.br ^bb15(%[[V_69]], %[[V_70:[0-9]+]] : index, index)
-! CHECK: ^bb19:  // pred: ^bb15
-! CHECK:   fir.freemem %[[V_24:[0-9]+]] : !fir.heap<!fir.array<?x2xf32>>
-! CHECK:   %[[V_73:[0-9]+]] = fir.call @_FortranAioBeginExternalListOutput(%[[C_6_i32]], %{{.*}}, %{{.*}}) {{.*}}: (i32, !fir.ref<i8>, i32) -> !fir.ref<i8>
-! CHECK:   %[[V_74:[0-9]+]] = fir.slice %[[C_1]], %[[C_2]], %[[C_1]], %[[C_1]], %[[C_2]], %[[C_1]] : (index, index, index, index, index, index) -> !fir.slice<2>
-! CHECK:   %[[V_75:[0-9]+]] = fir.embox %[[V_4]](%[[V_5]]) [%[[V_74]]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<2x?xf32>>
-! CHECK:   %[[V_76:[0-9]+]] = fir.convert %[[V_75:[0-9]+]] : (!fir.box<!fir.array<2x?xf32>>) -> !fir.box<none>
-! CHECK:   %[[V_77:[0-9]+]] = fir.call @_FortranAioOutputDescriptor(%[[V_73]], %[[V_76]]) fastmath<contract> {{.*}}: (!fir.ref<i8>, !fir.box<none>) -> i1
-! CHECK:   %[[V_78:[0-9]+]] = fir.load %arg0 : !fir.ref<i32>
-! CHECK:   %[[V_79:[0-9]+]] = arith.subi %[[V_78]], %[[C_1_i32]] : i32
-! CHECK:   %[[V_80:[0-9]+]] = fir.convert %[[V_79:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_81:[0-9]+]] = fir.convert %[[V_78:[0-9]+]] : (i32) -> index
-! CHECK:   %[[V_82:[0-9]+]] = fir.slice %[[V_80]], %[[V_81]], %[[C_1]], %[[C_1]], %[[C_2]], %[[C_1]] : (index, index, index, index, index, index) -> !fir.slice<2>
-! CHECK:   %[[V_83:[0-9]+]] = fir.embox %[[V_4]](%[[V_5]]) [%[[V_82]]] : (!fir.ref<!fir.array<?x2xf32>>, !fir.shape<2>, !fir.slice<2>) -> !fir.box<!fir.array<?x?xf32>>
-! CHECK:   %[[V_84:[0-9]+]] = fir.convert %[[V_83:[0-9]+]] : (!fir.box<!fir.array<?x?xf32>>) -> !fir.box<none>
-! CHECK:   %[[V_85:[0-9]+]] = fir.call @_FortranAioOutputDescriptor(%[[V_73]], %[[V_84]]) fastmath<contract> {{.*}}: (!fir.ref<i8>, !fir.box<none>) -> i1
-! CHECK:   %[[V_86:[0-9]+]] = fir.call @_FortranAioEndIoStatement(%[[V_73]]) fastmath<contract> {{.*}}: (!fir.ref<i8>) -> i32
-! CHECK:   return
-! CHECK:   }
 
 ! CHECK-LABEL: func @_QPtt1
 subroutine tt1

--- a/flang/test/Lower/identical-block-merge-disable.f90
+++ b/flang/test/Lower/identical-block-merge-disable.f90
@@ -36,100 +36,68 @@ END SUBROUTINE DMUMPS_SOL_FWD_LR_SU
 
 END MODULE DMUMPS_SOL_LR
 
-! CHECK-LABEL: func @_QMdmumps_sol_lrPdmumps_sol_fwd_lr_su(
-! CHECK-SAME:                                              %[[VAL_0:.*]]: !fir.ref<i32>{{.*}}, %[[VAL_1:.*]]: !fir.ref<i32>{{.*}}) {
-! CHECK-DAG:     %[[VAL_2:.*]] = arith.constant 0 : i64
-! CHECK-DAG:     %[[VAL_3:.*]] = arith.constant 0 : index
-! CHECK-DAG:     %[[VAL_4:.*]] = arith.constant 1 : i32
-! CHECK:         %[[VAL_5:.*]] = fir.address_of(@_QMdmumps_sol_lrEblr_array) : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_6:.*]] = fir.alloca i32 {bindc_name = "nb_blr", uniq_name = "_QMdmumps_sol_lrFdmumps_sol_fwd_lr_suEnb_blr"}
-! CHECK:         %[[VAL_7:.*]] = fir.alloca i32 {bindc_name = "npartsass", uniq_name = "_QMdmumps_sol_lrFdmumps_sol_fwd_lr_suEnpartsass"}
-! CHECK:         %[[VAL_8:.*]] = fir.load %[[VAL_1]] : !fir.ref<i32>
-! CHECK:         %[[VAL_9:.*]] = arith.cmpi eq, %[[VAL_8]], %[[VAL_4]] : i32
-! CHECK:         cond_br %[[VAL_9]], ^bb1, ^bb3
-! CHECK:       ^bb1:
-! CHECK:         %[[VAL_10:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_11:.*]]:3 = fir.box_dims %[[VAL_10]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_12:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_13:.*]] = fir.convert %[[VAL_12]] : (i32) -> i64
-! CHECK:         %[[VAL_14:.*]] = fir.convert %[[VAL_11]]#0 : (index) -> i64
-! CHECK:         %[[VAL_15:.*]] = arith.subi %[[VAL_13]], %[[VAL_14]] : i64
-! CHECK:         %[[VAL_16:.*]] = fir.coordinate_of %[[VAL_10]], %[[VAL_15]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_18:.*]] = fir.coordinate_of %[[VAL_16]], panels_l : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_19:.*]] = fir.load %[[VAL_18]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_20:.*]] = fir.box_addr %[[VAL_19]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.ptr<!fir.array<?xi32>>
-! CHECK:         %[[VAL_21:.*]] = fir.convert %[[VAL_20]] : (!fir.ptr<!fir.array<?xi32>>) -> i64
-! CHECK:         %[[VAL_22:.*]] = arith.cmpi ne, %[[VAL_21]], %[[VAL_2]] : i64
-! CHECK:         cond_br %[[VAL_22]], ^bb2, ^bb5
-! CHECK:       ^bb2:
-! CHECK:         %[[VAL_23:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_24:.*]]:3 = fir.box_dims %[[VAL_23]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_25:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_26:.*]] = fir.convert %[[VAL_25]] : (i32) -> i64
-! CHECK:         %[[VAL_27:.*]] = fir.convert %[[VAL_24]]#0 : (index) -> i64
-! CHECK:         %[[VAL_28:.*]] = arith.subi %[[VAL_26]], %[[VAL_27]] : i64
-! CHECK:         %[[VAL_29:.*]] = fir.coordinate_of %[[VAL_23]], %[[VAL_28]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_30:.*]] = fir.coordinate_of %[[VAL_29]], panels_l : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_31:.*]] = fir.load %[[VAL_30]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_32:.*]]:3 = fir.box_dims %[[VAL_31]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_33:.*]] = fir.convert %[[VAL_32]]#1 : (index) -> i32
-! CHECK:         fir.store %[[VAL_33]] to %[[VAL_7]] : !fir.ref<i32>
-! CHECK:         %[[VAL_34:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_35:.*]]:3 = fir.box_dims %[[VAL_34]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_36:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (i32) -> i64
-! CHECK:         %[[VAL_38:.*]] = fir.convert %[[VAL_35]]#0 : (index) -> i64
-! CHECK:         %[[VAL_39:.*]] = arith.subi %[[VAL_37]], %[[VAL_38]] : i64
-! CHECK:         %[[VAL_40:.*]] = fir.coordinate_of %[[VAL_34]], %[[VAL_39]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_42:.*]] = fir.coordinate_of %[[VAL_40]], begs_blr_static : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_43:.*]] = fir.load %[[VAL_42]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_44:.*]]:3 = fir.box_dims %[[VAL_43]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_45:.*]] = fir.convert %[[VAL_44]]#1 : (index) -> i32
-! CHECK:         %[[VAL_46:.*]] = arith.subi %[[VAL_45]], %[[VAL_4]] : i32
-! CHECK:         fir.store %[[VAL_46]] to %[[VAL_6]] : !fir.ref<i32>
-! CHECK:         br ^bb5
-! CHECK:       ^bb3:
-! CHECK:         %[[VAL_47:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_48:.*]]:3 = fir.box_dims %[[VAL_47]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_49:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_50:.*]] = fir.convert %[[VAL_49]] : (i32) -> i64
-! CHECK:         %[[VAL_51:.*]] = fir.convert %[[VAL_48]]#0 : (index) -> i64
-! CHECK:         %[[VAL_52:.*]] = arith.subi %[[VAL_50]], %[[VAL_51]] : i64
-! CHECK:         %[[VAL_53:.*]] = fir.coordinate_of %[[VAL_47]], %[[VAL_52]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_55:.*]] = fir.coordinate_of %[[VAL_53]], panels_u : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_56:.*]] = fir.load %[[VAL_55]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_57:.*]] = fir.box_addr %[[VAL_56]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.ptr<!fir.array<?xi32>>
-! CHECK:         %[[VAL_58:.*]] = fir.convert %[[VAL_57]] : (!fir.ptr<!fir.array<?xi32>>) -> i64
-! CHECK:         %[[VAL_59:.*]] = arith.cmpi ne, %[[VAL_58]], %[[VAL_2]] : i64
-! CHECK:         cond_br %[[VAL_59]], ^bb4, ^bb5
-! CHECK:       ^bb4:
-! CHECK:         %[[VAL_60:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_61:.*]]:3 = fir.box_dims %[[VAL_60]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_62:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_63:.*]] = fir.convert %[[VAL_62]] : (i32) -> i64
-! CHECK:         %[[VAL_64:.*]] = fir.convert %[[VAL_61]]#0 : (index) -> i64
-! CHECK:         %[[VAL_65:.*]] = arith.subi %[[VAL_63]], %[[VAL_64]] : i64
-! CHECK:         %[[VAL_66:.*]] = fir.coordinate_of %[[VAL_60]], %[[VAL_65]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_67:.*]] = fir.coordinate_of %[[VAL_66]], panels_u : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_68:.*]] = fir.load %[[VAL_67]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_69:.*]]:3 = fir.box_dims %[[VAL_68]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_70:.*]] = fir.convert %[[VAL_69]]#1 : (index) -> i32
-! CHECK:         fir.store %[[VAL_70]] to %[[VAL_7]] : !fir.ref<i32>
-! CHECK:         %[[VAL_71:.*]] = fir.load %[[VAL_5]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
-! CHECK:         %[[VAL_72:.*]]:3 = fir.box_dims %[[VAL_71]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_73:.*]] = fir.load %[[VAL_0]] : !fir.ref<i32>
-! CHECK:         %[[VAL_74:.*]] = fir.convert %[[VAL_73]] : (i32) -> i64
-! CHECK:         %[[VAL_75:.*]] = fir.convert %[[VAL_72]]#0 : (index) -> i64
-! CHECK:         %[[VAL_76:.*]] = arith.subi %[[VAL_74]], %[[VAL_75]] : i64
-! CHECK:         %[[VAL_77:.*]] = fir.coordinate_of %[[VAL_71]], %[[VAL_76]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
-! CHECK:         %[[VAL_79:.*]] = fir.coordinate_of %[[VAL_77]], begs_blr_static : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_80:.*]] = fir.load %[[VAL_79]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
-! CHECK:         %[[VAL_81:.*]]:3 = fir.box_dims %[[VAL_80]], %[[VAL_3]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
-! CHECK:         %[[VAL_82:.*]] = fir.convert %[[VAL_81]]#1 : (index) -> i32
-! CHECK:         %[[VAL_83:.*]] = arith.subi %[[VAL_82]], %[[VAL_4]] : i32
-! CHECK:         fir.store %[[VAL_83]] to %[[VAL_6]] : !fir.ref<i32>
-! CHECK:         br ^bb5
-! CHECK:       ^bb5:
-! CHECK:         return
-! CHECK:       }
-
+! CHECK-LABEL:   func.func @_QMdmumps_sol_lrPdmumps_sol_fwd_lr_su(
+! CHECK-SAME:      %[[ARG0:.*]]: !fir.ref<i32> {fir.bindc_name = "iwhdlr"},
+! CHECK-SAME:      %[[ARG1:.*]]: !fir.ref<i32> {fir.bindc_name = "mtype"}) {
+! CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i64
+! CHECK:           %[[VAL_1:.*]] = arith.constant 0 : index
+! CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i32
+! CHECK:           %[[VAL_3:.*]] = fir.address_of(@_QMdmumps_sol_lrEblr_array) : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
+! CHECK:           %[[VAL_4:.*]] = fir.alloca i32 {bindc_name = "nb_blr", uniq_name = "_QMdmumps_sol_lrFdmumps_sol_fwd_lr_suEnb_blr"}
+! CHECK:           %[[VAL_5:.*]] = fir.alloca i32 {bindc_name = "npartsass", uniq_name = "_QMdmumps_sol_lrFdmumps_sol_fwd_lr_suEnpartsass"}
+! CHECK:           %[[VAL_6:.*]] = fir.load %[[ARG1]] : !fir.ref<i32>
+! CHECK:           %[[VAL_7:.*]] = arith.cmpi eq, %[[VAL_6]], %[[VAL_2]] : i32
+! CHECK:           cf.cond_br %[[VAL_7]], ^bb1, ^bb3
+! CHECK:         ^bb1:
+! CHECK:           %[[VAL_8:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
+! CHECK:           %[[VAL_9:.*]]:3 = fir.box_dims %[[VAL_8]], %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_10:.*]] = fir.load %[[ARG0]] : !fir.ref<i32>
+! CHECK:           %[[VAL_11:.*]] = fir.convert %[[VAL_10]] : (i32) -> i64
+! CHECK:           %[[VAL_12:.*]] = fir.convert %[[VAL_9]]#0 : (index) -> i64
+! CHECK:           %[[VAL_13:.*]] = arith.subi %[[VAL_11]], %[[VAL_12]] : i64
+! CHECK:           %[[VAL_14:.*]] = fir.coordinate_of %[[VAL_8]], %[[VAL_13]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
+! CHECK:           %[[VAL_15:.*]] = fir.coordinate_of %[[VAL_14]], panels_l : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_16:.*]] = fir.load %[[VAL_15]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_17:.*]] = fir.box_addr %[[VAL_16]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.ptr<!fir.array<?xi32>>
+! CHECK:           %[[VAL_18:.*]] = fir.convert %[[VAL_17]] : (!fir.ptr<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_19:.*]] = arith.cmpi ne, %[[VAL_18]], %[[VAL_0]] : i64
+! CHECK:           cf.cond_br %[[VAL_19]], ^bb2, ^bb5
+! CHECK:         ^bb2:
+! CHECK:           %[[VAL_20:.*]]:3 = fir.box_dims %[[VAL_16]], %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_21:.*]] = fir.convert %[[VAL_20]]#1 : (index) -> i32
+! CHECK:           fir.store %[[VAL_21]] to %[[VAL_5]] : !fir.ref<i32>
+! CHECK:           %[[VAL_22:.*]] = fir.coordinate_of %[[VAL_14]], begs_blr_static : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_23:.*]] = fir.load %[[VAL_22]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_24:.*]]:3 = fir.box_dims %[[VAL_23]], %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_25:.*]] = fir.convert %[[VAL_24]]#1 : (index) -> i32
+! CHECK:           %[[VAL_26:.*]] = arith.subi %[[VAL_25]], %[[VAL_2]] : i32
+! CHECK:           fir.store %[[VAL_26]] to %[[VAL_4]] : !fir.ref<i32>
+! CHECK:           cf.br ^bb5
+! CHECK:         ^bb3:
+! CHECK:           %[[VAL_27:.*]] = fir.load %[[VAL_3]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>>
+! CHECK:           %[[VAL_28:.*]]:3 = fir.box_dims %[[VAL_27]], %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_29:.*]] = fir.load %[[ARG0]] : !fir.ref<i32>
+! CHECK:           %[[VAL_30:.*]] = fir.convert %[[VAL_29]] : (i32) -> i64
+! CHECK:           %[[VAL_31:.*]] = fir.convert %[[VAL_28]]#0 : (index) -> i64
+! CHECK:           %[[VAL_32:.*]] = arith.subi %[[VAL_30]], %[[VAL_31]] : i64
+! CHECK:           %[[VAL_33:.*]] = fir.coordinate_of %[[VAL_27]], %[[VAL_32]] : (!fir.box<!fir.ptr<!fir.array<?x!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>>>, i64) -> !fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>
+! CHECK:           %[[VAL_34:.*]] = fir.coordinate_of %[[VAL_33]], panels_u : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_35:.*]] = fir.load %[[VAL_34]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_36:.*]] = fir.box_addr %[[VAL_35]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>) -> !fir.ptr<!fir.array<?xi32>>
+! CHECK:           %[[VAL_37:.*]] = fir.convert %[[VAL_36]] : (!fir.ptr<!fir.array<?xi32>>) -> i64
+! CHECK:           %[[VAL_38:.*]] = arith.cmpi ne, %[[VAL_37]], %[[VAL_0]] : i64
+! CHECK:           cf.cond_br %[[VAL_38]], ^bb4, ^bb5
+! CHECK:         ^bb4:
+! CHECK:           %[[VAL_39:.*]]:3 = fir.box_dims %[[VAL_35]], %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_40:.*]] = fir.convert %[[VAL_39]]#1 : (index) -> i32
+! CHECK:           fir.store %[[VAL_40]] to %[[VAL_5]] : !fir.ref<i32>
+! CHECK:           %[[VAL_41:.*]] = fir.coordinate_of %[[VAL_33]], begs_blr_static : (!fir.ref<!fir.type<_QMdmumps_sol_lrTblr_struc_t{panels_l:!fir.box<!fir.ptr<!fir.array<?xi32>>>,panels_u:!fir.box<!fir.ptr<!fir.array<?xi32>>>,begs_blr_static:!fir.box<!fir.ptr<!fir.array<?xi32>>>}>>) -> !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_42:.*]] = fir.load %[[VAL_41]] : !fir.ref<!fir.box<!fir.ptr<!fir.array<?xi32>>>>
+! CHECK:           %[[VAL_43:.*]]:3 = fir.box_dims %[[VAL_42]], %[[VAL_1]] : (!fir.box<!fir.ptr<!fir.array<?xi32>>>, index) -> (index, index, index)
+! CHECK:           %[[VAL_44:.*]] = fir.convert %[[VAL_43]]#1 : (index) -> i32
+! CHECK:           %[[VAL_45:.*]] = arith.subi %[[VAL_44]], %[[VAL_2]] : i32
+! CHECK:           fir.store %[[VAL_45]] to %[[VAL_4]] : !fir.ref<i32>
+! CHECK:           cf.br ^bb5
+! CHECK:         ^bb5:
+! CHECK:           return
+! CHECK:         }

--- a/flang/test/Lower/vector-subscript-io.f90
+++ b/flang/test/Lower/vector-subscript-io.f90
@@ -83,13 +83,11 @@ subroutine only_once(x)
 ! CHECK:   %[[VAL_54:.*]] = arith.subi %[[VAL_44]], %[[VAL_30]] : index
 ! CHECK:   cf.br ^bb1(%[[VAL_53]], %[[VAL_54]] : index, index)
 ! CHECK: ^bb3:
-! CHECK:   %[[VAL_55:.*]] = fir.load %[[VAL_31]] : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>
-! CHECK:   %[[VAL_56:.*]] = fir.box_addr %[[VAL_55]] : (!fir.box<!fir.heap<!fir.array<?xi32>>>) -> !fir.heap<!fir.array<?xi32>>
-! CHECK:   %[[VAL_57:.*]] = fir.convert %[[VAL_56]] : (!fir.heap<!fir.array<?xi32>>) -> i64
+! CHECK:   %[[VAL_57:.*]] = fir.convert %[[VAL_40]] : (!fir.heap<!fir.array<?xi32>>) -> i64
 ! CHECK:   %[[VAL_58:.*]] = arith.cmpi ne, %[[VAL_57]], %[[VAL_28]] : i64
 ! CHECK:   cf.cond_br %[[VAL_58]], ^bb4, ^bb5
 ! CHECK: ^bb4:
-! CHECK:   fir.freemem %[[VAL_56]] : !fir.heap<!fir.array<?xi32>>
+! CHECK:   fir.freemem %[[VAL_40]] : !fir.heap<!fir.array<?xi32>>
 ! CHECK:   cf.br ^bb5
 ! CHECK: ^bb5:
 ! CHECK:   %[[VAL_59:.*]] = fir.call @_FortranAioEndIoStatement(%[[VAL_34]]) {{.*}}: (!fir.ref<i8>) -> i32
@@ -579,3 +577,4 @@ subroutine iostat_in_io_loop(k, j, stat)
 ! CHECK:   fir.store %[[VAL_407]] to %[[VAL_408]] : !fir.ref<i32>
 ! CHECK:   return
 end subroutine
+


### PR DESCRIPTION
The test `flang/test/Lower/array-constructor-2.f90` gave me the most pause because the filecheck tests are for after cfg-conversion. This is me convincing myself that CSE is not doing anything unsafe in this test case:

What changed at the hlfir level?

```diff
   %43 = fir.load %13 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
   %44 = fir.box_addr %43 : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
   %45 = fir.convert %44 : (!fir.heap<!fir.array<?xf32>>) -> i64
   %46 = arith.cmpi ne, %45, %c0_i64 : i64
   fir.if %46 {
-    %51 = fir.load %13 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
-    %52 = fir.box_addr %51 : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
-    fir.freemem %52 : !fir.heap<!fir.array<?xf32>>
+    fir.freemem %44 : !fir.heap<!fir.array<?xf32>>
     fir.store %10 to %13 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
   }
   %47 = fir.load %11 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
   %48 = fir.box_addr %47 : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
   %49 = fir.convert %48 : (!fir.heap<!fir.array<?xf32>>) -> i64
   %50 = arith.cmpi ne, %49, %c0_i64 : i64
   fir.if %50 {
-    %51 = fir.load %11 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
-    %52 = fir.box_addr %51 : (!fir.box<!fir.heap<!fir.array<?xf32>>>) -> !fir.heap<!fir.array<?xf32>>
-    fir.freemem %52 : !fir.heap<!fir.array<?xf32>>
+    fir.freemem %48 : !fir.heap<!fir.array<?xf32>>
     fir.store %10 to %11 : !fir.ref<!fir.box<!fir.heap<!fir.array<?xf32>>>>
   }
```

Does anything change after that first run with the additional CSE'd loads in the if branches? No:
```
> rg "Number of operations [DCS]+E" mine2.mlir dev2.mlir
mine2.mlir
18542:  (S) 123 num-cse'd - Number of operations CSE'd
18543:  (S)  28 num-dce'd - Number of operations DCE'd
18557:  (S) 0 num-cse'd - Number of operations CSE'd
18558:  (S) 0 num-dce'd - Number of operations DCE'd
18564:  (S) 0 num-cse'd - Number of operations CSE'd
18565:  (S) 0 num-dce'd - Number of operations DCE'd
18587:  (S) 1 num-cse'd - Number of operations CSE'd
18588:  (S) 0 num-dce'd - Number of operations DCE'd

dev2.mlir
18716:  (S) 117 num-cse'd - Number of operations CSE'd
18717:  (S)  28 num-dce'd - Number of operations DCE'd
18731:  (S) 0 num-cse'd - Number of operations CSE'd
18732:  (S) 0 num-dce'd - Number of operations DCE'd
18738:  (S) 0 num-cse'd - Number of operations CSE'd
18739:  (S) 0 num-dce'd - Number of operations DCE'd
18761:  (S) 0 num-cse'd - Number of operations CSE'd
18762:  (S) 0 num-dce'd - Number of operations DCE'd
```